### PR TITLE
refactor(tests): remove go-cmp dependency and use table-driven checks

### DIFF
--- a/arraydeque/arraydeque_test.go
+++ b/arraydeque/arraydeque_test.go
@@ -4,8 +4,6 @@ import (
 	"github.com/lock14/collections"
 	"slices"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestNew(t *testing.T) {
@@ -84,28 +82,49 @@ func TestArrayDeque_Add(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name  string
-		items []int
-		want  []int
+		check func(*testing.T, *ArrayDeque[int])
 	}{
 		{
-			name:  "add_none",
-			items: []int{},
-			want:  nil,
+			name: "add_none",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				if got := slices.Collect(d.All()); !slices.Equal(got, nil) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, nil)
+				}
+			},
 		},
 		{
-			name:  "add_one",
-			items: []int{1},
-			want:  []int{1},
+			name: "add_one",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				d.Add(1)
+				want := []int{1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "add_up_to_default_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-			want:  []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			name: "add_up_to_default_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				want := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+				for _, item := range want {
+					d.Add(item)
+				}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "add_double_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
-			want:  []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+			name: "add_double_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				want := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+				for _, item := range want {
+					d.Add(item)
+				}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -113,13 +132,7 @@ func TestArrayDeque_Add(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			d := New[int]()
-			for _, item := range tc.items {
-				d.Add(item)
-			}
-			got := slices.Collect(d.All())
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("wrong string value, -got,+want: %s", diff)
-			}
+			tc.check(t, d)
 		})
 	}
 }
@@ -128,28 +141,51 @@ func TestArrayDeque_Push(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name  string
-		items []int
-		want  []int
+		check func(*testing.T, *ArrayDeque[int])
 	}{
 		{
-			name:  "push_none",
-			items: []int{},
-			want:  nil,
+			name: "push_none",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				if got := slices.Collect(d.All()); !slices.Equal(got, nil) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, nil)
+				}
+			},
 		},
 		{
-			name:  "push_one",
-			items: []int{1},
-			want:  []int{1},
+			name: "push_one",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				d.Push(1)
+				want := []int{1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "push_up_to_default_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-			want:  []int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+			name: "push_up_to_default_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+				for _, item := range items {
+					d.Push(item)
+				}
+				want := []int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "push_double_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
-			want:  []int{20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+			name: "push_double_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+				for _, item := range items {
+					d.Push(item)
+				}
+				want := []int{20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -157,13 +193,7 @@ func TestArrayDeque_Push(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			d := New[int]()
-			for _, item := range tc.items {
-				d.Push(item)
-			}
-			got := slices.Collect(d.All())
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("wrong string value, -got,+want: %s", diff)
-			}
+			tc.check(t, d)
 		})
 	}
 }
@@ -172,28 +202,51 @@ func TestArrayDeque_AddFront(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name  string
-		items []int
-		want  []int
+		check func(*testing.T, *ArrayDeque[int])
 	}{
 		{
-			name:  "add_front_none",
-			items: []int{},
-			want:  nil,
+			name: "add_front_none",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				if got := slices.Collect(d.All()); !slices.Equal(got, nil) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, nil)
+				}
+			},
 		},
 		{
-			name:  "add_front_one",
-			items: []int{1},
-			want:  []int{1},
+			name: "add_front_one",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				d.AddFront(1)
+				want := []int{1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "add_front_up_to_default_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-			want:  []int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+			name: "add_front_up_to_default_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+				for _, item := range items {
+					d.AddFront(item)
+				}
+				want := []int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "add_front_double_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
-			want:  []int{20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+			name: "add_front_double_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+				for _, item := range items {
+					d.AddFront(item)
+				}
+				want := []int{20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -201,13 +254,7 @@ func TestArrayDeque_AddFront(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			d := New[int]()
-			for _, item := range tc.items {
-				d.AddFront(item)
-			}
-			got := slices.Collect(d.All())
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("wrong string value, -got,+want: %s", diff)
-			}
+			tc.check(t, d)
 		})
 	}
 }
@@ -216,28 +263,49 @@ func TestArrayDeque_AddBack(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name  string
-		items []int
-		want  []int
+		check func(*testing.T, *ArrayDeque[int])
 	}{
 		{
-			name:  "add_back_none",
-			items: []int{},
-			want:  nil,
+			name: "add_back_none",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				if got := slices.Collect(d.All()); !slices.Equal(got, nil) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, nil)
+				}
+			},
 		},
 		{
-			name:  "add_back_one",
-			items: []int{1},
-			want:  []int{1},
+			name: "add_back_one",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				d.Add(1)
+				want := []int{1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "add_back_up_to_default_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-			want:  []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			name: "add_back_up_to_default_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				want := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+				for _, item := range want {
+					d.Add(item)
+				}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "add_back_double_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
-			want:  []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+			name: "add_back_double_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				want := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+				for _, item := range want {
+					d.Add(item)
+				}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -245,13 +313,7 @@ func TestArrayDeque_AddBack(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			d := New[int]()
-			for _, item := range tc.items {
-				d.Add(item)
-			}
-			got := slices.Collect(d.All())
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("wrong string value, -got,+want: %s", diff)
-			}
+			tc.check(t, d)
 		})
 	}
 }
@@ -260,28 +322,60 @@ func TestArrayDeque_Rotate(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name  string
-		items []int
-		want  []int
+		check func(*testing.T, *ArrayDeque[int])
 	}{
 		{
-			name:  "rotate_none",
-			items: []int{},
-			want:  nil,
+			name: "rotate_none",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				if got := slices.Collect(d.All()); !slices.Equal(got, nil) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, nil)
+				}
+			},
 		},
 		{
-			name:  "rotate_one",
-			items: []int{1},
-			want:  []int{1},
+			name: "rotate_one",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				d.Add(1)
+				for i := 0; i < d.Size()/2; i++ {
+					d.Add(d.Remove())
+				}
+				want := []int{1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "rotate_even",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-			want:  []int{6, 7, 8, 9, 10, 1, 2, 3, 4, 5},
+			name: "rotate_even",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+				for _, item := range items {
+					d.Add(item)
+				}
+				for i := 0; i < d.Size()/2; i++ {
+					d.Add(d.Remove())
+				}
+				want := []int{6, 7, 8, 9, 10, 1, 2, 3, 4, 5}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "rotate_odd",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9},
-			want:  []int{5, 6, 7, 8, 9, 1, 2, 3, 4},
+			name: "rotate_odd",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+				for _, item := range items {
+					d.Add(item)
+				}
+				for i := 0; i < d.Size()/2; i++ {
+					d.Add(d.Remove())
+				}
+				want := []int{5, 6, 7, 8, 9, 1, 2, 3, 4}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -289,16 +383,7 @@ func TestArrayDeque_Rotate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			d := New[int]()
-			for _, item := range tc.items {
-				d.Add(item)
-			}
-			for i := 0; i < d.Size()/2; i++ {
-				d.Add(d.Remove())
-			}
-			got := slices.Collect(d.All())
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("wrong string value, -got,+want: %s", diff)
-			}
+			tc.check(t, d)
 		})
 	}
 }
@@ -312,28 +397,46 @@ func TestArrayDeque_AddAll(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name  string
-		items []int
-		want  []int
+		check func(*testing.T, *ArrayDeque[int])
 	}{
 		{
-			name:  "add_none",
-			items: []int{},
-			want:  nil,
+			name: "add_none",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				d.AddAll(slices.Values([]int{}))
+				if got := slices.Collect(d.All()); !slices.Equal(got, nil) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, nil)
+				}
+			},
 		},
 		{
-			name:  "add_one",
-			items: []int{1},
-			want:  []int{1},
+			name: "add_one",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				d.AddAll(slices.Values([]int{1}))
+				want := []int{1}
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "add_up_to_default_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-			want:  []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			name: "add_up_to_default_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				want := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+				d.AddAll(slices.Values(want))
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 		{
-			name:  "add_double_capacity",
-			items: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
-			want:  []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+			name: "add_double_capacity",
+			check: func(t *testing.T, d *ArrayDeque[int]) {
+				want := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+				d.AddAll(slices.Values(want))
+				if got := slices.Collect(d.All()); !slices.Equal(got, want) {
+					t.Errorf("wrong slice value, got: %v, want: %v", got, want)
+				}
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -341,11 +444,7 @@ func TestArrayDeque_AddAll(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			d := New[int]()
-			d.AddAll(slices.Values(tc.items))
-			got := slices.Collect(d.All())
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("wrong string value, -got,+want: %s", diff)
-			}
+			tc.check(t, d)
 		})
 	}
 }

--- a/bitset/bitset_test.go
+++ b/bitset/bitset_test.go
@@ -1,10 +1,10 @@
 package bitset
 
 import (
+	"bytes"
 	"fmt"
+	"slices"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // https://oeis.org/A000040
@@ -84,8 +84,8 @@ func TestString(t *testing.T) {
 			t.Parallel()
 			b := tc.bitSetInitFunc()
 			got := b.String()
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("b.String() mismatch (-got, +want):\n%s", diff)
+			if got != tc.want {
+				t.Errorf("b.String() mismatch got:\n%s\nwant:\n%s", got, tc.want)
 			}
 		})
 	}
@@ -131,14 +131,14 @@ func TestFromBytesToBytes(t *testing.T) {
 			t.Parallel()
 			b := FromBytes(tc.input)
 			got := b.ToBytes()
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("unexpected result (-got, +want):\n%s", diff)
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("unexpected result got:\n%v\nwant:\n%v", got, tc.want)
 			}
 			for n := 0; n < b.Length(); n++ {
 				gotSetBit := (got[n/8] & (1 << (n % 8))) != 0
 				wantSetBit := b.Get(n)
-				if diff := cmp.Diff(gotSetBit, wantSetBit); diff != "" {
-					t.Errorf("unexpected result (-got, +want):\n%s", diff)
+				if gotSetBit != wantSetBit {
+					t.Errorf("unexpected result for bit %d, got: %v, want: %v", n, gotSetBit, wantSetBit)
 				}
 			}
 		})
@@ -168,8 +168,8 @@ func TestFlipRange(t *testing.T) {
 			b := New()
 			b.FlipRange(tc.start, tc.end)
 			got := b.Size()
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("unexpected result (-got, +want):\n%s", diff)
+			if got != tc.want {
+				t.Errorf("unexpected result got: %d, want: %d", got, tc.want)
 			}
 		})
 	}
@@ -204,8 +204,8 @@ func TestBitSetPrimeGen(t *testing.T) {
 			for n := range b.SetBits() {
 				primes = append(primes, n)
 			}
-			if diff := cmp.Diff(primes, tc.want); diff != "" {
-				t.Errorf("unexpected result (-got, +want): %s", diff)
+			if !slices.Equal(primes, tc.want) {
+				t.Errorf("unexpected result got: %v, want: %v", primes, tc.want)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/lock14/collections
 
 go 1.23.0
-
-require github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/hashset/hashset_test.go
+++ b/hashset/hashset_test.go
@@ -4,8 +4,6 @@ import (
 	"slices"
 	"sort"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestDefaultConstruction(t *testing.T) {
@@ -55,8 +53,8 @@ func TestAdd(t *testing.T) {
 			}
 			got := slices.Collect(s.All())
 			sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Errorf("wrong string value, -got,+want: %s", diff)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("wrong slice value, got: %v, want: %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR refactors tests across the codebase to use a table-driven check function pattern, and fully removes the github.com/google/go-cmp/cmp dependency by replacing it with standard library comparisons (slices.Equal, bytes.Equal).