### PR TITLE
perf(arraydeque): optimize initial capacity and add benchmarks

### DIFF
--- a/arraydeque/arraydeque.go
+++ b/arraydeque/arraydeque.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// DefaultCapacity is the capacity assigned if no other is provided.
-	DefaultCapacity = 1
+	DefaultCapacity = 16
 	// if an arraydeque's capacity is under this amount its capacity
 	// will double when it needs to be resized.
 	doublingThreshold = 512

--- a/arraydeque/arraydeque_bench_test.go
+++ b/arraydeque/arraydeque_bench_test.go
@@ -1,0 +1,114 @@
+package arraydeque
+
+import (
+	"testing"
+)
+
+func BenchmarkArrayDeque_AddFront(b *testing.B) {
+	d := New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.AddFront(i)
+	}
+}
+
+func BenchmarkArrayDeque_AddBack(b *testing.B) {
+	d := New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.AddBack(i)
+	}
+}
+
+func BenchmarkArrayDeque_PushPop(b *testing.B) {
+	d := New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.Push(i)
+		d.Pop()
+	}
+}
+
+func BenchmarkArrayDeque_AddRemove(b *testing.B) {
+	d := New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.AddBack(i)
+		d.RemoveFront()
+	}
+}
+
+func BenchmarkArrayDeque_AddFront_Preallocated(b *testing.B) {
+	d := New[int](func(c *Config) { c.Capacity = b.N })
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.AddFront(i)
+	}
+}
+
+func BenchmarkArrayDeque_AddBack_Preallocated(b *testing.B) {
+	d := New[int](func(c *Config) { c.Capacity = b.N })
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.AddBack(i)
+	}
+}
+
+func BenchmarkArrayDeque_IterateAll(b *testing.B) {
+	d := New[int]()
+	for i := 0; i < 1000; i++ {
+		d.AddBack(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _ = range d.All() {
+		}
+	}
+}
+
+func BenchmarkArrayDeque_IterateBackward(b *testing.B) {
+	d := New[int]()
+	for i := 0; i < 1000; i++ {
+		d.AddBack(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _ = range d.Backward() {
+		}
+	}
+}
+
+type largeStruct struct {
+	a, b, c, d, e, f, g, h int64
+}
+
+func BenchmarkArrayDeque_StructAddBack(b *testing.B) {
+	d := New[largeStruct]()
+	item := largeStruct{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.AddBack(item)
+	}
+}
+
+func BenchmarkArrayDeque_ClearAndReuse_NewEachTime(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d := New[int]()
+		for j := 0; j < 100; j++ {
+			d.AddBack(j)
+		}
+		d.Clear() // Simulate clearing out the old one before tossing it
+	}
+}
+
+func BenchmarkArrayDeque_ClearAndReuse_Existing(b *testing.B) {
+	d := New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 100; j++ {
+			d.AddBack(j)
+		}
+		d.Clear() // Actually reuse it next iteration
+	}
+}

--- a/arraydeque/arraydeque_test.go
+++ b/arraydeque/arraydeque_test.go
@@ -896,37 +896,3 @@ func TestArrayDeque_Backward_Break(t *testing.T) {
 		})
 	}
 }
-
-func BenchmarkArrayDeque_AddFront(b *testing.B) {
-	d := New[int]()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		d.AddFront(i)
-	}
-}
-
-func BenchmarkArrayDeque_AddBack(b *testing.B) {
-	d := New[int]()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		d.AddBack(i)
-	}
-}
-
-func BenchmarkArrayDeque_PushPop(b *testing.B) {
-	d := New[int]()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		d.Push(i)
-		d.Pop()
-	}
-}
-
-func BenchmarkArrayDeque_AddRemove(b *testing.B) {
-	d := New[int]()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		d.AddBack(i)
-		d.RemoveFront()
-	}
-}

--- a/arraydeque/arraydeque_test.go
+++ b/arraydeque/arraydeque_test.go
@@ -896,3 +896,37 @@ func TestArrayDeque_Backward_Break(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkArrayDeque_AddFront(b *testing.B) {
+	d := New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.AddFront(i)
+	}
+}
+
+func BenchmarkArrayDeque_AddBack(b *testing.B) {
+	d := New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.AddBack(i)
+	}
+}
+
+func BenchmarkArrayDeque_PushPop(b *testing.B) {
+	d := New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.Push(i)
+		d.Pop()
+	}
+}
+
+func BenchmarkArrayDeque_AddRemove(b *testing.B) {
+	d := New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.AddBack(i)
+		d.RemoveFront()
+	}
+}


### PR DESCRIPTION
This PR introduces standard benchmarks for the ArrayDeque operations. By profiling the ArrayDeque, it became apparent that the starting capacity of 1 caused excessive allocations when growing dynamically. Changing the DefaultCapacity from 1 to 16 improves initial append throughput and limits reallocation overhead.