### PR TITLE
fix(bitset): comprehensive review fixes and optimizations

### DIFF
--- a/bitset/bitset.go
+++ b/bitset/bitset.go
@@ -53,9 +53,11 @@ func New(opts ...Option) *BitSet {
 // Clear sets the bit specified by the index to false.
 func (b *BitSet) Clear(bit int) {
 	index, shift := convert(bit)
-	b.ensureSize(index)
+	if index >= len(b.bits) {
+		return
+	}
 	b.bits[index] &= ^(1 << shift)
-	if index == b.maxWordInUse && b.bits[index] == 0 {
+	if index == b.maxWordInUse-1 && b.bits[index] == 0 {
 		b.maxWordInUse = b.lastNonZeroWord() + 1
 	}
 }
@@ -65,15 +67,17 @@ func (b *BitSet) Set(bit int) {
 	index, shift := convert(bit)
 	b.ensureSize(index)
 	b.bits[index] |= 1 << shift
-	if index > b.maxWordInUse {
-		b.maxWordInUse = index
+	if index+1 > b.maxWordInUse {
+		b.maxWordInUse = index + 1
 	}
 }
 
 // Get returns the value of the bit with the specified index.
 func (b *BitSet) Get(bit int) bool {
 	index, shift := convert(bit)
-	b.ensureSize(index)
+	if index >= len(b.bits) {
+		return false
+	}
 	return (b.bits[index]>>shift)&1 == 1
 }
 
@@ -193,41 +197,18 @@ func (b *BitSet) String() string {
 	return strings.Join(s, "")
 }
 
-func (b *BitSet) All() iter.Seq[int] {
-	return func(yield func(int) bool) {
-		for bitIndex := 0; bitIndex < b.Size() && yield(bitIndex); {
-			bitIndex++
-		}
-	}
-}
-
-// SetBits returns an iterator that iterates over the set bits of this BitSet
+// SetBits returns an iterator that iterates over the set bits of this BitSet.
+// It uses word-level iteration with bits.TrailingZeros64 for efficiency.
 func (b *BitSet) SetBits() iter.Seq[int] {
 	return func(yield func(int) bool) {
-		bitIndex := 0
-		for bitIndex < b.Size() && !b.Get(bitIndex) {
-			bitIndex++
-		}
-		for bitIndex < b.Size() && yield(bitIndex) {
-			bitIndex++
-			for bitIndex < b.Size() && !b.Get(bitIndex) {
-				bitIndex++
-			}
-		}
-	}
-}
-
-// UnsetBits returns an iterator that iterates over the unset bits of this BitSet
-func (b *BitSet) UnsetBits() iter.Seq[int] {
-	return func(yield func(int) bool) {
-		bitIndex := 0
-		for bitIndex < b.Size() && b.Get(bitIndex) {
-			bitIndex++
-		}
-		for bitIndex < b.Size() && yield(bitIndex) {
-			bitIndex++
-			for bitIndex < b.Size() && b.Get(bitIndex) {
-				bitIndex++
+		for i := 0; i < len(b.bits); i++ {
+			word := b.bits[i]
+			for word != 0 {
+				tz := bits.TrailingZeros64(word)
+				if !yield(i*wordSize + tz) {
+					return
+				}
+				word &= word - 1 // clear lowest set bit
 			}
 		}
 	}
@@ -245,8 +226,10 @@ func defaultConfig() *Config {
 }
 
 func (b *BitSet) ensureSize(index int) {
-	for index >= len(b.bits) {
-		b.bits = append(b.bits, 0)
+	if index >= len(b.bits) {
+		newBits := make([]uint64, index+1)
+		copy(newBits, b.bits)
+		b.bits = newBits
 	}
 }
 

--- a/bitset/bitset_test.go
+++ b/bitset/bitset_test.go
@@ -231,3 +231,282 @@ func primesLessThan(n int) *BitSet {
 	}
 	return b
 }
+
+func TestLength(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		check func(*testing.T, *BitSet)
+	}{
+		{
+			name: "empty_bitset",
+			check: func(t *testing.T, b *BitSet) {
+				if got := b.Length(); got != 0 {
+					t.Errorf("expected 0, got %d", got)
+				}
+			},
+		},
+		{
+			name: "set_bit_0",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(0)
+				if got := b.Length(); got != 1 {
+					t.Errorf("expected 1, got %d", got)
+				}
+			},
+		},
+		{
+			name: "set_bit_5",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(5)
+				if got := b.Length(); got != 6 {
+					t.Errorf("expected 6, got %d", got)
+				}
+			},
+		},
+		{
+			name: "set_bit_63",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(63)
+				if got := b.Length(); got != 64 {
+					t.Errorf("expected 64, got %d", got)
+				}
+			},
+		},
+		{
+			name: "set_bit_64",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(64)
+				if got := b.Length(); got != 65 {
+					t.Errorf("expected 65, got %d", got)
+				}
+			},
+		},
+		{
+			name: "set_multiple_bits_in_word_0",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(3)
+				b.Set(10)
+				b.Set(7)
+				if got := b.Length(); got != 11 {
+					t.Errorf("expected 11, got %d", got)
+				}
+			},
+		},
+		{
+			name: "set_bits_across_words",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(5)
+				b.Set(100)
+				if got := b.Length(); got != 101 {
+					t.Errorf("expected 101, got %d", got)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := New()
+			tc.check(t, b)
+		})
+	}
+}
+
+func TestClear(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		check func(*testing.T, *BitSet)
+	}{
+		{
+			name: "clear_set_bit",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(5)
+				b.Clear(5)
+				if b.Get(5) {
+					t.Errorf("expected bit 5 to be unset after Clear")
+				}
+			},
+		},
+		{
+			name: "clear_updates_length",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(5)
+				b.Set(10)
+				b.Clear(10)
+				if got := b.Length(); got != 6 {
+					t.Errorf("expected Length 6 after clearing highest bit, got %d", got)
+				}
+			},
+		},
+		{
+			name: "clear_only_bit_in_word_0",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(3)
+				b.Clear(3)
+				if got := b.Length(); got != 0 {
+					t.Errorf("expected Length 0, got %d", got)
+				}
+			},
+		},
+		{
+			name: "clear_out_of_range_does_not_grow",
+			check: func(t *testing.T, b *BitSet) {
+				sizeBefore := b.Size()
+				b.Clear(1000)
+				if got := b.Size(); got != sizeBefore {
+					t.Errorf("Clear on out-of-range bit grew the BitSet from %d to %d", sizeBefore, got)
+				}
+			},
+		},
+		{
+			name: "clear_unset_bit_is_noop",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(5)
+				b.Clear(3)
+				if !b.Get(5) {
+					t.Errorf("clearing an unset bit should not affect other bits")
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := New()
+			tc.check(t, b)
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		check func(*testing.T, *BitSet)
+	}{
+		{
+			name: "get_out_of_range_returns_false",
+			check: func(t *testing.T, b *BitSet) {
+				if b.Get(1000) {
+					t.Errorf("expected false for out-of-range bit")
+				}
+			},
+		},
+		{
+			name: "get_out_of_range_does_not_grow",
+			check: func(t *testing.T, b *BitSet) {
+				sizeBefore := b.Size()
+				b.Get(1000)
+				if got := b.Size(); got != sizeBefore {
+					t.Errorf("Get on out-of-range bit grew the BitSet from %d to %d", sizeBefore, got)
+				}
+			},
+		},
+		{
+			name: "get_negative_panics",
+			check: func(t *testing.T, b *BitSet) {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected panic for negative index")
+					}
+				}()
+				b.Get(-1)
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := New()
+			tc.check(t, b)
+		})
+	}
+}
+
+func TestSet_Negative_Panics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for negative index")
+		}
+	}()
+	b := New()
+	b.Set(-1)
+}
+
+func TestSetBits(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		check func(*testing.T, *BitSet)
+	}{
+		{
+			name: "no_bits_set",
+			check: func(t *testing.T, b *BitSet) {
+				got := slices.Collect(b.SetBits())
+				if len(got) != 0 {
+					t.Errorf("expected no set bits, got: %v", got)
+				}
+			},
+		},
+		{
+			name: "sparse_bits",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(0)
+				b.Set(63)
+				b.Set(64)
+				b.Set(127)
+				want := []int{0, 63, 64, 127}
+				got := slices.Collect(b.SetBits())
+				if !slices.Equal(got, want) {
+					t.Errorf("wrong set bits, got: %v, want: %v", got, want)
+				}
+			},
+		},
+		{
+			name: "early_break",
+			check: func(t *testing.T, b *BitSet) {
+				b.Set(1)
+				b.Set(5)
+				b.Set(100)
+				got := []int{}
+				for n := range b.SetBits() {
+					got = append(got, n)
+					if n == 5 {
+						break
+					}
+				}
+				want := []int{1, 5}
+				if !slices.Equal(got, want) {
+					t.Errorf("wrong set bits, got: %v, want: %v", got, want)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := New(NumBits(128))
+			tc.check(t, b)
+		})
+	}
+}
+
+func TestNew_ZeroBits(t *testing.T) {
+	t.Parallel()
+	b := New(NumBits(0))
+	if got := b.Size(); got != 0 {
+		t.Errorf("expected Size 0, got %d", got)
+	}
+	b.Set(5) // should grow without panic
+	if !b.Get(5) {
+		t.Errorf("expected bit 5 to be set after growing from zero")
+	}
+}
+


### PR DESCRIPTION
This PR applies several fixes and optimizations to the bitset package:

- **Fix:** Fixed a critical bug in Set and Clear where maxWordInUse was incorrectly tracked using an inclusive index instead of an exclusive count, causing Length() to return 0 when only bits in word 0 were set.
- **Semantic Fix:** Changed Get and Clear so they no longer silently append to the underlying slice if an out-of-bounds index is passed.
- **Optimization:** Refactored nsureSize to grow the slice in a single allocation (make + copy) instead of repeatedly calling ppend in a loop.
- **Optimization:** Rewrote the SetBits iterator to use word-level iteration and its.TrailingZeros64 for a massive performance improvement.
- **Cleanup:** Removed the All and UnsetBits iterators as requested.
- **Testing:** Added exhaustive test coverage for Length, Get, Clear, and the SetBits iterator, explicitly targeting edge cases and negative indices.