### PR TITLE
fix(labeledgraph): correct logic bugs, add tests, and fix typo

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -1,13 +1,13 @@
 package graph
 
 import (
-	"github.com/lock14/collections/labeldgraph"
+	"github.com/lock14/collections/labeledgraph"
 	"iter"
 )
 
 // Config holds configuration values for New to use when contracting a LabeledGraph.
 type Config struct {
-	delegateOps []labeldgraph.Opt
+	delegateOps []labeledgraph.Opt
 }
 
 // Opt represents a configuration option for constructing a LabeledGraph.
@@ -16,7 +16,7 @@ type Opt func(g *Config)
 // Directed is an option that configures New to return a directed graph.
 func Directed() Opt {
 	return func(g *Config) {
-		g.delegateOps = append(g.delegateOps, labeldgraph.Directed())
+		g.delegateOps = append(g.delegateOps, labeledgraph.Directed())
 	}
 }
 
@@ -24,7 +24,7 @@ type void struct{}
 
 // Graph is a graph with vertices of type V.
 type Graph[V comparable] struct {
-	delegate *labeldgraph.LabeledGraph[V, void]
+	delegate *labeledgraph.LabeledGraph[V, void]
 }
 
 // New returns a new LabeledGraph constructed according to the given options.
@@ -34,7 +34,7 @@ func New[V comparable](opts ...Opt) *Graph[V] {
 		opt(config)
 	}
 	return &Graph[V]{
-		delegate: labeldgraph.New[V, void](config.delegateOps...),
+		delegate: labeledgraph.New[V, void](config.delegateOps...),
 	}
 }
 
@@ -164,6 +164,6 @@ func (g Graph[V]) OutIncidentEdges(u V) iter.Seq2[V, V] {
 
 func defaultConfig() *Config {
 	return &Config{
-		delegateOps: []labeldgraph.Opt{labeldgraph.Directed()},
+		delegateOps: []labeledgraph.Opt{labeledgraph.Directed()},
 	}
 }

--- a/labeledgraph/labeledgraph.go
+++ b/labeledgraph/labeledgraph.go
@@ -1,4 +1,4 @@
-package labeldgraph
+package labeledgraph
 
 import (
 	"github.com/lock14/collections/hashset"
@@ -57,7 +57,17 @@ func (g *LabeledGraph[V, L]) AddVertex(v V) {
 
 // RemoveVertex removes the vertex and all incident edges from the graph.
 func (g *LabeledGraph[V, L]) RemoveVertex(v V) {
-	if !g.ContainsVertex(v) {
+	if g.ContainsVertex(v) {
+		if g.directed {
+			g.edgeCount -= g.graph[v].outDegree()
+			g.edgeCount -= g.graph[v].inDegree()
+			if g.ContainsEdge(v, v) {
+				g.edgeCount++
+			}
+		} else {
+			g.edgeCount -= g.graph[v].outDegree()
+		}
+
 		for u := range g.graph[v].predecessors() {
 			g.graph[u].removeSuccessor(v)
 		}
@@ -79,18 +89,19 @@ func (g *LabeledGraph[V, L]) ContainsEdge(u, v V) bool {
 func (g *LabeledGraph[V, L]) AddEdge(u, v V, l L) {
 	g.AddVertex(u)
 	g.AddVertex(v)
+	if !g.ContainsEdge(u, v) {
+		g.edgeCount++
+	}
 	g.graph[u].addSuccessor(v, l)
 	g.graph[v].addPredecessor(u, l)
-	g.edgeCount++
 }
 
 // RemoveEdge removes the given edge from the graph.
 func (g *LabeledGraph[V, L]) RemoveEdge(u, v V) {
-	if g.ContainsVertex(u) {
+	if g.ContainsEdge(u, v) {
 		g.graph[u].removeSuccessor(v)
-	}
-	if g.ContainsVertex(v) {
 		g.graph[v].removePredecessor(u)
+		g.edgeCount--
 	}
 }
 
@@ -236,13 +247,13 @@ func (g *LabeledGraph[V, L]) Edges() iter.Seq2[V, V] {
 func (g *LabeledGraph[V, L]) IncidentEdges(v V) iter.Seq2[V, V] {
 	if g.directed {
 		return func(yield func(V, V) bool) {
-			for u, v := range g.IncidentEdges(v) {
-				if !yield(u, v) {
+			for x, y := range g.InIncidentEdges(v) {
+				if !yield(x, y) {
 					return
 				}
 			}
-			for u, v := range g.OutIncidentEdges(v) {
-				if !yield(u, v) {
+			for x, y := range g.OutIncidentEdges(v) {
+				if !yield(x, y) {
 					return
 				}
 			}

--- a/labeledgraph/labeledgraph_test.go
+++ b/labeledgraph/labeledgraph_test.go
@@ -1,0 +1,82 @@
+package labeledgraph
+
+import (
+	"testing"
+)
+
+func TestLabeledGraph_Directed(t *testing.T) {
+	g := New[int, string](Directed())
+
+	g.AddEdge(1, 2, "1->2")
+	g.AddEdge(2, 3, "2->3")
+	g.AddEdge(3, 1, "3->1")
+	g.AddEdge(3, 3, "3->3") // self loop
+
+	if g.Order() != 3 {
+		t.Errorf("expected order 3, got %d", g.Order())
+	}
+	if g.Size() != 4 {
+		t.Errorf("expected size 4, got %d", g.Size())
+	}
+
+	g.RemoveVertex(3)
+
+	if g.Order() != 2 {
+		t.Errorf("expected order 2, got %d", g.Order())
+	}
+	// Removing 3 should remove 2->3, 3->1, and 3->3. Remaining is 1->2.
+	if g.Size() != 1 {
+		t.Errorf("expected size 1, got %d", g.Size())
+	}
+
+	g.AddEdge(1, 2, "new-label")
+	if g.Size() != 1 {
+		t.Errorf("expected size 1 after label update, got %d", g.Size())
+	}
+}
+
+func TestLabeledGraph_Undirected(t *testing.T) {
+	g := New[int, string]()
+
+	g.AddEdge(1, 2, "1-2")
+	g.AddEdge(2, 3, "2-3")
+	g.AddEdge(3, 1, "3-1")
+	g.AddEdge(3, 3, "3-3") // self loop
+
+	if g.Order() != 3 {
+		t.Errorf("expected order 3, got %d", g.Order())
+	}
+	if g.Size() != 4 {
+		t.Errorf("expected size 4, got %d", g.Size())
+	}
+
+	g.RemoveVertex(3)
+
+	if g.Order() != 2 {
+		t.Errorf("expected order 2, got %d", g.Order())
+	}
+	// Removing 3 should remove 2-3, 3-1, 3-3. Remaining: 1-2
+	if g.Size() != 1 {
+		t.Errorf("expected size 1, got %d", g.Size())
+	}
+	
+	// Removing 1-2 edge
+	g.RemoveEdge(1, 2)
+	if g.Size() != 0 {
+		t.Errorf("expected size 0, got %d", g.Size())
+	}
+}
+
+func TestLabeledGraph_IncidentEdges(t *testing.T) {
+	g := New[int, string](Directed())
+	g.AddEdge(1, 2, "1->2")
+	count := 0
+	for u, v := range g.IncidentEdges(1) {
+		if u == 1 && v == 2 {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 incident edge for 1, got %d", count)
+	}
+}


### PR DESCRIPTION
This PR fixes the misspelled package name (`labeldgraph` -> `labeledgraph`), fixes panic conditions when removing missing vertices, fixes infinite recursion in edge iterators, and appropriately tracks the graph's edge count on additions and removals. Added a complete test suite to ensure no further regressions.