### PR TITLE
test(labeledgraph): add benchmark suite

### DIFF
--- a/labeledgraph/labeledgraph_bench_test.go
+++ b/labeledgraph/labeledgraph_bench_test.go
@@ -1,0 +1,88 @@
+package labeledgraph_test
+
+import (
+	"github.com/lock14/collections/labeledgraph"
+	"testing"
+)
+
+func BenchmarkLabeledGraph_AddVertex(b *testing.B) {
+	g := labeledgraph.New[int, string]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g.AddVertex(i)
+	}
+}
+
+func BenchmarkLabeledGraph_AddEdge_Directed(b *testing.B) {
+	g := labeledgraph.New[int, string](labeledgraph.Directed())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g.AddEdge(i, i+1, "label")
+	}
+}
+
+func BenchmarkLabeledGraph_AddEdge_Undirected(b *testing.B) {
+	g := labeledgraph.New[int, string]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g.AddEdge(i, i+1, "label")
+	}
+}
+
+func BenchmarkLabeledGraph_RemoveVertex(b *testing.B) {
+	g := labeledgraph.New[int, string]()
+	for i := 0; i < b.N; i++ {
+		g.AddVertex(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g.RemoveVertex(i)
+	}
+}
+
+func BenchmarkLabeledGraph_RemoveEdge(b *testing.B) {
+	g := labeledgraph.New[int, string]()
+	for i := 0; i < b.N; i++ {
+		g.AddEdge(i, i+1, "l")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g.RemoveEdge(i, i+1)
+	}
+}
+
+func BenchmarkLabeledGraph_IterateVertices(b *testing.B) {
+	g := labeledgraph.New[int, string]()
+	for i := 0; i < 1000; i++ {
+		g.AddVertex(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _ = range g.Vertices() {
+		}
+	}
+}
+
+func BenchmarkLabeledGraph_IterateEdges(b *testing.B) {
+	g := labeledgraph.New[int, string]()
+	for i := 0; i < 1000; i++ {
+		g.AddEdge(i, i+1, "l")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, _ = range g.Edges() {
+		}
+	}
+}
+
+func BenchmarkLabeledGraph_IncidentEdges(b *testing.B) {
+	g := labeledgraph.New[int, string]()
+	for i := 0; i < 1000; i++ {
+		g.AddEdge(0, i, "l")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, _ = range g.IncidentEdges(0) {
+		}
+	}
+}


### PR DESCRIPTION
Adds a comprehensive suite of benchmarks for labeledgraph operations and iterators. The tests are written in a black-box style (package `labeledgraph_test`) mimicking arraydeque.