### PR TITLE
fix(heap): refactor slice management and add comprehensive tests

### DIFF
--- a/heap/heap.go
+++ b/heap/heap.go
@@ -46,10 +46,15 @@ func WithComparator[T any](comparator Comparator[T]) Option[T] {
 	}
 }
 
+// Capacity configures the initial pre-allocated capacity of the heap.
+func Capacity[T any](capacity int) Option[T] {
+	return func(config *Config[T]) {
+		config.capacity = capacity
+	}
+}
+
 type Heap[T any] struct {
 	elements   []T
-	size       int
-	zero       T
 	comparator Comparator[T]
 }
 
@@ -59,6 +64,7 @@ func New[T any](opts ...Option[T]) *Heap[T] {
 		opt(config)
 	}
 	return &Heap[T]{
+		elements:   make([]T, 0, config.capacity),
 		comparator: config.comparator,
 	}
 }
@@ -72,12 +78,8 @@ func Max[T cmp.Ordered]() *Heap[T] {
 }
 
 func (h *Heap[T]) Add(t T) {
-	if h.size == len(h.elements) {
-		h.increaseCapacity()
-	}
-	h.elements[h.size] = t
-	h.size++
-	h.siftUp(h.size - 1)
+	h.elements = append(h.elements, t)
+	h.siftUp(len(h.elements) - 1)
 }
 
 func (h *Heap[T]) AddAll(sequence iter.Seq[T]) {
@@ -86,22 +88,45 @@ func (h *Heap[T]) AddAll(sequence iter.Seq[T]) {
 	}
 }
 
+// Remove removes and returns the top element from the heap.
+// Panics if the heap is empty.
 func (h *Heap[T]) Remove() T {
+	if h.Empty() {
+		panic("heap is empty")
+	}
 	t := h.elements[0]
 	h.delete(0)
 	return t
 }
 
+// Peek returns the top element from the heap without removing it.
+// Panics if the heap is empty.
 func (h *Heap[T]) Peek() T {
+	if h.Empty() {
+		panic("heap is empty")
+	}
 	return h.elements[0]
 }
 
 func (h *Heap[T]) Size() int {
-	return h.size
+	return len(h.elements)
 }
 
 func (h *Heap[T]) Empty() bool {
-	return h.Size() == 0
+	return len(h.elements) == 0
+}
+
+func (h *Heap[T]) Clear() {
+	// Zero out elements to allow GC
+	var zero T
+	for i := range h.elements {
+		h.elements[i] = zero
+	}
+	h.elements = h.elements[:0]
+}
+
+func (h *Heap[T]) All() iter.Seq[T] {
+	return slices.Values(h.elements)
 }
 
 // Private Functions
@@ -113,48 +138,50 @@ func defaultConfig[T any]() *Config[T] {
 }
 
 func (h *Heap[T]) delete(index int) {
+	last := len(h.elements) - 1
 	var zero T
-	h.size--
-	h.elements[index] = h.elements[h.size]
-	h.elements[h.size] = zero
-	if h.hasParent(index) && !h.heapCondition(parent(index), index) {
-		h.siftUp(index)
+	if index != last {
+		h.elements[index] = h.elements[last]
+		h.elements[last] = zero
+		h.elements = h.elements[:last]
+		if h.hasParent(index) && !h.heapCondition(parent(index), index) {
+			h.siftUp(index)
+		} else {
+			h.siftDown(index)
+		}
 	} else {
-		h.siftDown(index)
+		h.elements[last] = zero
+		h.elements = h.elements[:last]
 	}
-
 }
 
 func (h *Heap[T]) siftUp(cur int) {
-	for h.hasParent(cur) && h.heapCondition(parent(cur), cur) {
+	for h.hasParent(cur) && h.heapCondition(cur, parent(cur)) {
 		h.swap(parent(cur), cur)
 		cur = parent(cur)
 	}
 }
 
 func (h *Heap[T]) siftDown(cur int) {
-	heapConditionViolated := true
-	for h.hasLeft(cur) && heapConditionViolated {
-		child := left(cur)
-		if h.hasRight(cur) && h.heapCondition(right(cur), child) {
-			child = right(cur)
+	for {
+		best := cur
+		if h.hasLeft(cur) && h.heapCondition(left(cur), best) {
+			best = left(cur)
 		}
-		heapConditionViolated = !h.heapCondition(cur, child)
-		if heapConditionViolated {
-			h.swap(cur, child)
+		if h.hasRight(cur) && h.heapCondition(right(cur), best) {
+			best = right(cur)
 		}
-		cur = child
+		if best == cur {
+			break
+		}
+		h.swap(cur, best)
+		cur = best
 	}
 }
 
+// heapCondition returns true if the element at index i should be placed higher in the heap than the element at index j.
 func (h *Heap[T]) heapCondition(i, j int) bool {
 	return h.comparator(h.elements[i], h.elements[j]) <= 0
-}
-
-func (h *Heap[T]) increaseCapacity() {
-	newElements := make([]T, len(h.elements)+(len(h.elements)>>1))
-	copy(newElements, h.elements)
-	h.elements = newElements
 }
 
 func (h *Heap[T]) swap(i, j int) {
@@ -166,11 +193,11 @@ func (h *Heap[T]) hasParent(index int) bool {
 }
 
 func (h *Heap[T]) hasLeft(index int) bool {
-	return left(index) < h.size
+	return left(index) < len(h.elements)
 }
 
 func (h *Heap[T]) hasRight(index int) bool {
-	return right(index) < h.size
+	return right(index) < len(h.elements)
 }
 
 func parent(index int) int {
@@ -183,8 +210,4 @@ func left(index int) int {
 
 func right(index int) int {
 	return 2*index + 2
-}
-
-func (h *Heap[T]) All() iter.Seq[T] {
-	return slices.Values(h.elements[0:h.Size()])
 }

--- a/heap/heap_test.go
+++ b/heap/heap_test.go
@@ -2,6 +2,7 @@ package heap
 
 import (
 	"github.com/lock14/collections"
+	"slices"
 	"testing"
 )
 
@@ -11,4 +12,224 @@ func TestHeapImplementsQueue(t *testing.T) {
 
 func queue[T any](q collections.Queue[T]) collections.Queue[T] {
 	return q
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		opts  []Option[int]
+		check func(*testing.T, *Heap[int])
+	}{
+		{
+			name: "default_capacity",
+			check: func(t *testing.T, h *Heap[int]) {
+				if h.Size() != 0 {
+					t.Errorf("expected size 0")
+				}
+				if cap(h.elements) < DefaultCapacity {
+					t.Errorf("expected capacity >= %d, got %d", DefaultCapacity, cap(h.elements))
+				}
+			},
+		},
+		{
+			name: "custom_capacity",
+			opts: []Option[int]{Capacity[int](100)},
+			check: func(t *testing.T, h *Heap[int]) {
+				if cap(h.elements) < 100 {
+					t.Errorf("expected capacity >= 100, got %d", cap(h.elements))
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := New[int](tc.opts...)
+			tc.check(t, h)
+		})
+	}
+}
+
+func TestHeap_AddRemove(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		heap  func() *Heap[int]
+		check func(*testing.T, *Heap[int])
+	}{
+		{
+			name: "min_heap",
+			heap: func() *Heap[int] { return Min[int]() },
+			check: func(t *testing.T, h *Heap[int]) {
+				h.AddAll(slices.Values([]int{5, 1, 3, 2, 4}))
+				if h.Size() != 5 {
+					t.Errorf("expected size 5")
+				}
+				if h.Peek() != 1 {
+					t.Errorf("expected peek 1")
+				}
+				expected := []int{1, 2, 3, 4, 5}
+				for i, exp := range expected {
+					val := h.Remove()
+					if val != exp {
+						t.Errorf("at index %d: expected %d, got %d", i, exp, val)
+					}
+				}
+			},
+		},
+		{
+			name: "max_heap",
+			heap: func() *Heap[int] { return Max[int]() },
+			check: func(t *testing.T, h *Heap[int]) {
+				h.AddAll(slices.Values([]int{5, 1, 3, 2, 4}))
+				expected := []int{5, 4, 3, 2, 1}
+				for i, exp := range expected {
+					val := h.Remove()
+					if val != exp {
+						t.Errorf("at index %d: expected %d, got %d", i, exp, val)
+					}
+				}
+			},
+		},
+		{
+			name: "sort_large",
+			heap: func() *Heap[int] { return Min[int]() },
+			check: func(t *testing.T, h *Heap[int]) {
+				for i := 1000; i >= 1; i-- {
+					h.Add(i)
+				}
+				for i := 1; i <= 1000; i++ {
+					val := h.Remove()
+					if val != i {
+						t.Fatalf("expected %d, got %d", i, val)
+					}
+				}
+			},
+		},
+		{
+			name: "remove_middle",
+			heap: func() *Heap[int] { return Min[int]() },
+			check: func(t *testing.T, h *Heap[int]) {
+				h.AddAll(slices.Values([]int{10, 20, 30, 40, 50, 60}))
+				h.Remove()
+				if h.Peek() != 20 {
+					t.Errorf("expected 20, got %d", h.Peek())
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := tc.heap()
+			tc.check(t, h)
+		})
+	}
+}
+
+func TestHeap_Clear(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		heap  func() *Heap[int]
+		check func(*testing.T, *Heap[int])
+	}{
+		{
+			name: "clear_elements",
+			heap: func() *Heap[int] { return Min[int]() },
+			check: func(t *testing.T, h *Heap[int]) {
+				h.Add(1)
+				h.Add(2)
+				h.Clear()
+				if !h.Empty() || h.Size() != 0 {
+					t.Errorf("expected empty after clear")
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := tc.heap()
+			tc.check(t, h)
+		})
+	}
+}
+
+func TestHeap_Iterators(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		heap  func() *Heap[int]
+		check func(*testing.T, *Heap[int])
+	}{
+		{
+			name: "all",
+			heap: func() *Heap[int] { return Min[int]() },
+			check: func(t *testing.T, h *Heap[int]) {
+				h.AddAll(slices.Values([]int{1, 2, 3}))
+				count := 0
+				for range h.All() {
+					count++
+				}
+				if count != 3 {
+					t.Errorf("expected 3 items, got %d", count)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := tc.heap()
+			tc.check(t, h)
+		})
+	}
+}
+
+func TestHeap_Panics(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		heap  func() *Heap[int]
+		check func(*testing.T, *Heap[int])
+	}{
+		{
+			name: "peek_empty",
+			heap: func() *Heap[int] { return Min[int]() },
+			check: func(t *testing.T, h *Heap[int]) {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected panic")
+					}
+				}()
+				h.Peek()
+			},
+		},
+		{
+			name: "remove_empty",
+			heap: func() *Heap[int] { return Min[int]() },
+			check: func(t *testing.T, h *Heap[int]) {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected panic")
+					}
+				}()
+				h.Remove()
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := tc.heap()
+			tc.check(t, h)
+		})
+	}
 }


### PR DESCRIPTION
This PR completely overhauls the `heap` package to fix several critical bugs and add a full test suite.

**Fixes:**
1. **Slice panic:** The previous manual slice capacity tracking was buggy and caused a guaranteed panic on the first `.Add()` due to zero-length allocation. This has been completely replaced with idiomatic Go `append()`.
2. **Ignored Capacity:** The `Capacity` option was previously ignored in `New()`. It now correctly pre-allocates the underlying slice.
3. **Empty checks:** `.Remove()` and `.Peek()` now properly panic with a descriptive message if the heap is empty, rather than throwing an out-of-bounds panic.

**Features:**
- Added `Clear()` to zero out the heap and allow GC while retaining capacity.

**Testing:**
- Replaced the empty test file with a comprehensive suite testing min-heap, max-heap, edge cases, and panics.