### PR TITLE
test(linkedhashmap): add benchmark suite

### DIFF
--- a/linkedhashmap/linkedhashmap_bench_test.go
+++ b/linkedhashmap/linkedhashmap_bench_test.go
@@ -1,0 +1,70 @@
+package linkedhashmap_test
+
+import (
+	"github.com/lock14/collections/linkedhashmap"
+	"testing"
+)
+
+func BenchmarkLinkedHashMap_Put(b *testing.B) {
+	m := linkedhashmap.New[int, int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Put(i, i)
+	}
+}
+
+func BenchmarkLinkedHashMap_Put_Evict(b *testing.B) {
+	m := linkedhashmap.New[int, int](linkedhashmap.WithMaxElements(1000))
+	for i := 0; i < 1000; i++ {
+		m.Put(i, i)
+	}
+	b.ResetTimer()
+	for i := 1000; i < b.N+1000; i++ {
+		m.Put(i, i)
+	}
+}
+
+func BenchmarkLinkedHashMap_Get_InsertionOrder(b *testing.B) {
+	m := linkedhashmap.New[int, int]()
+	for i := 0; i < 1000; i++ {
+		m.Put(i, i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Get(i % 1000)
+	}
+}
+
+func BenchmarkLinkedHashMap_Get_AccessOrder(b *testing.B) {
+	m := linkedhashmap.New[int, int](linkedhashmap.WithAccessOrder())
+	for i := 0; i < 1000; i++ {
+		m.Put(i, i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Get(i % 1000)
+	}
+}
+
+func BenchmarkLinkedHashMap_Remove(b *testing.B) {
+	m := linkedhashmap.New[int, int]()
+	for i := 0; i < b.N; i++ {
+		m.Put(i, i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Remove(i)
+	}
+}
+
+func BenchmarkLinkedHashMap_IterateAll(b *testing.B) {
+	m := linkedhashmap.New[int, int]()
+	for i := 0; i < 1000; i++ {
+		m.Put(i, i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _ = range m.All() {
+		}
+	}
+}


### PR DESCRIPTION
Adds a comprehensive suite of benchmarks for linkedhashmap operations. This tracks performance of insertions, LRU evictions, and access-order node unlinking overhead.