### PR TITLE
perf(linkedlist): inline memory operations

### DIFF
--- a/linkedlist/linkedlist.go
+++ b/linkedlist/linkedlist.go
@@ -31,31 +31,45 @@ func New[T any]() *LinkedList[T] {
 }
 
 func (l *LinkedList[T]) AddFront(t T) {
-	insertBefore(l.list.next, t)
+	n := &node[T]{
+		data: t,
+		prev: &l.list,
+		next: l.list.next,
+	}
+	l.list.next.prev = n
+	l.list.next = n
 	l.size++
 }
 
 func (l *LinkedList[T]) RemoveFront() T {
-	if l.Empty() {
+	if l.size == 0 {
 		panic("cannot remove from an empty list")
 	}
 	n := l.list.next
-	unlink(n)
+	l.list.next = n.next
+	n.next.prev = &l.list
 	l.size--
 	return n.data
 }
 
 func (l *LinkedList[T]) AddBack(t T) {
-	insertBefore(&l.list, t)
+	n := &node[T]{
+		data: t,
+		prev: l.list.prev,
+		next: &l.list,
+	}
+	l.list.prev.next = n
+	l.list.prev = n
 	l.size++
 }
 
 func (l *LinkedList[T]) RemoveBack() T {
-	if l.Empty() {
+	if l.size == 0 {
 		panic("cannot remove from an empty list")
 	}
 	n := l.list.prev
-	unlink(n)
+	l.list.prev = n.prev
+	n.prev.next = &l.list
 	l.size--
 	return n.data
 }
@@ -65,14 +79,14 @@ func (l *LinkedList[T]) Peek() T {
 }
 
 func (l *LinkedList[T]) PeekFront() T {
-	if l.Empty() {
+	if l.size == 0 {
 		panic("cannot peek from an empty list")
 	}
 	return l.list.next.data
 }
 
 func (l *LinkedList[T]) PeekBack() T {
-	if l.Empty() {
+	if l.size == 0 {
 		panic("cannot peek from an empty list")
 	}
 	return l.list.prev.data
@@ -120,7 +134,7 @@ func (l *LinkedList[T]) AddAll(sequence iter.Seq[T]) {
 }
 
 func (l *LinkedList[T]) Empty() bool {
-	return l.Size() == 0
+	return l.size == 0
 }
 
 func (l *LinkedList[T]) Clear() {
@@ -164,21 +178,6 @@ func (l *LinkedList[T]) get(idx int) *node[T] {
 	}
 }
 
-func insertBefore[T any](n *node[T], t T) {
-	newNode := &node[T]{
-		data: t,
-		prev: n.prev,
-		next: n,
-	}
-	n.prev.next = newNode
-	n.prev = newNode
-}
 
-func unlink[T any](n *node[T]) {
-	n.prev.next = n.next
-	n.next.prev = n.prev
-	n.prev = nil
-	n.next = nil
-}
 
 

--- a/linkedlist/linkedlist_bench_test.go
+++ b/linkedlist/linkedlist_bench_test.go
@@ -1,0 +1,67 @@
+package linked_list_test
+
+import (
+	"github.com/lock14/collections/linkedlist"
+	"testing"
+)
+
+func BenchmarkLinkedList_AddFront(b *testing.B) {
+	l := linked_list.New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.AddFront(i)
+	}
+}
+
+func BenchmarkLinkedList_AddBack(b *testing.B) {
+	l := linked_list.New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.AddBack(i)
+	}
+}
+
+func BenchmarkLinkedList_RemoveFront(b *testing.B) {
+	l := linked_list.New[int]()
+	for i := 0; i < b.N; i++ {
+		l.AddBack(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.RemoveFront()
+	}
+}
+
+func BenchmarkLinkedList_RemoveBack(b *testing.B) {
+	l := linked_list.New[int]()
+	for i := 0; i < b.N; i++ {
+		l.AddBack(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.RemoveBack()
+	}
+}
+
+func BenchmarkLinkedList_Get(b *testing.B) {
+	l := linked_list.New[int]()
+	for i := 0; i < 1000; i++ {
+		l.AddBack(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Get(i % 1000)
+	}
+}
+
+func BenchmarkLinkedList_IterateAll(b *testing.B) {
+	l := linked_list.New[int]()
+	for i := 0; i < 1000; i++ {
+		l.AddBack(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _ = range l.All() {
+		}
+	}
+}


### PR DESCRIPTION
Optimized linkedlist by inlining the internal node unlink/insertBefore helpers. Also removed the protective `nil`ing out of pointers during node removals; since nodes are internal to the package and not exposed to the user, they immediately become unreachable after removal, meaning the garbage collector can reclaim them safely without needing extra memory writes to severe their outgoing pointers.