### PR TITLE
fix(hashset): resolve retain/remove bugs and add test suite

### DIFF
--- a/hashset/hashset.go
+++ b/hashset/hashset.go
@@ -16,10 +16,19 @@ type HashSet[T comparable] struct {
 }
 
 // Config holds the values for configuring a HashSet.
-type Config struct{}
+type Config struct {
+	capacity int
+}
 
 // Option configures a HashSet config
 type Option func(*Config)
+
+// WithCapacity configures the initial capacity of the HashSet.
+func WithCapacity(capacity int) Option {
+	return func(c *Config) {
+		c.capacity = capacity
+	}
+}
 
 // New creates an empty HashSet.
 func New[T comparable](opts ...Option) *HashSet[T] {
@@ -28,7 +37,7 @@ func New[T comparable](opts ...Option) *HashSet[T] {
 		option(config)
 	}
 	return &HashSet[T]{
-		m: make(map[T]struct{}),
+		m: make(map[T]struct{}, config.capacity),
 	}
 }
 
@@ -37,12 +46,11 @@ func (s *HashSet[T]) Add(item T) {
 }
 
 func (s *HashSet[T]) Remove() T {
-	var t T
 	for item := range s.m {
-		t = item
-		break
+		delete(s.m, item)
+		return item
 	}
-	return t
+	panic("cannot remove from an empty set")
 }
 
 func (s *HashSet[T]) RemoveElement(item T) {
@@ -76,11 +84,17 @@ func (s *HashSet[T]) RemoveAll(other collections.Collection[T]) {
 }
 
 func (s *HashSet[T]) RetainAll(other collections.Collection[T]) {
+	newMap := make(map[T]struct{})
 	for t := range other.All() {
-		if !s.Contains(t) {
-			s.RemoveElement(t)
+		if _, ok := s.m[t]; ok {
+			newMap[t] = struct{}{}
 		}
 	}
+	s.m = newMap
+}
+
+func (s *HashSet[T]) Clear() {
+	s.m = make(map[T]struct{})
 }
 
 func (s *HashSet[T]) Size() int {
@@ -88,15 +102,13 @@ func (s *HashSet[T]) Size() int {
 }
 
 func (s *HashSet[T]) Empty() bool {
-	return s.Size() == 0
+	return len(s.m) == 0
 }
 
 func (s *HashSet[T]) String() string {
-	vals := make([]string, s.Size())
-	i := 0
-	for item := range maps.Keys(s.m) {
-		vals[i] = fmt.Sprintf("%+v", item)
-		i++
+	vals := make([]string, 0, len(s.m))
+	for item := range s.m {
+		vals = append(vals, fmt.Sprintf("%+v", item))
 	}
 	return "[" + strings.Join(vals, ", ") + "]"
 }

--- a/hashset/hashset_bench_test.go
+++ b/hashset/hashset_bench_test.go
@@ -1,0 +1,59 @@
+package hashset_test
+
+import (
+	"github.com/lock14/collections/hashset"
+	"testing"
+)
+
+func BenchmarkHashSet_Add(b *testing.B) {
+	s := hashset.New[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Add(i)
+	}
+}
+
+func BenchmarkHashSet_Add_Preallocated(b *testing.B) {
+	s := hashset.New[int](hashset.WithCapacity(b.N))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Add(i)
+	}
+}
+
+func BenchmarkHashSet_Contains(b *testing.B) {
+	s := hashset.New[int]()
+	for i := 0; i < 1000; i++ {
+		s.Add(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Contains(i % 1000)
+	}
+}
+
+func BenchmarkHashSet_RemoveElement(b *testing.B) {
+	s := hashset.New[int]()
+	for i := 0; i < b.N; i++ {
+		s.Add(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.RemoveElement(i)
+	}
+}
+
+func BenchmarkHashSet_RetainAll(b *testing.B) {
+	s := hashset.New[int]()
+	for i := 0; i < 1000; i++ {
+		s.Add(i)
+	}
+	other := hashset.New[int]()
+	for i := 0; i < 500; i++ {
+		other.Add(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.RetainAll(other)
+	}
+}

--- a/hashset/hashset_test.go
+++ b/hashset/hashset_test.go
@@ -6,41 +6,106 @@ import (
 	"testing"
 )
 
-func TestDefaultConstruction(t *testing.T) {
-	t.Parallel()
-	s := New[int]()
-	if size := s.Size(); size != 0 {
-		t.Errorf("new hashset has non-zero size: %d", size)
-	}
-	if !s.Empty() {
-		t.Error("new hashset reports not empty")
-	}
-	if str := s.String(); str != "[]" {
-		t.Errorf("new hashset has wrong String(): %s", str)
-	}
-}
-
-func TestAdd(t *testing.T) {
+func TestNew(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name  string
-		items []int
-		want  []int
+		opts  []Option
+		check func(*testing.T, *HashSet[int])
 	}{
 		{
-			name:  "add_none",
-			items: []int{},
-			want:  nil,
+			name: "default",
+			check: func(t *testing.T, s *HashSet[int]) {
+				if s.Size() != 0 || !s.Empty() {
+					t.Errorf("expected empty set")
+				}
+			},
 		},
 		{
-			name:  "add_one",
-			items: []int{1},
-			want:  []int{1},
+			name: "capacity",
+			opts: []Option{WithCapacity(100)},
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.Add(1)
+				if s.Size() != 1 {
+					t.Errorf("expected size 1")
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := New[int](tc.opts...)
+			tc.check(t, s)
+		})
+	}
+}
+
+func TestHashSet_AddRemoveContains(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		check func(*testing.T, *HashSet[int])
+	}{
+		{
+			name: "add_and_contains",
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.Add(2) // duplicate
+				if s.Size() != 2 {
+					t.Errorf("expected size 2")
+				}
+				if !s.Contains(1) || !s.Contains(2) || s.Contains(3) {
+					t.Errorf("contains failed")
+				}
+			},
 		},
 		{
-			name:  "add_duplicates",
-			items: []int{1, 2, 2, 1, 2, 1, 1},
-			want:  []int{1, 2},
+			name: "remove_element",
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.RemoveElement(1)
+				if s.Contains(1) || s.Size() != 1 {
+					t.Errorf("remove failed")
+				}
+			},
+		},
+		{
+			name: "remove_arbitrary",
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.Add(1)
+				val := s.Remove()
+				if val != 1 {
+					t.Errorf("expected to remove 1")
+				}
+				if !s.Empty() {
+					t.Errorf("expected empty")
+				}
+			},
+		},
+		{
+			name: "remove_empty_panic",
+			check: func(t *testing.T, s *HashSet[int]) {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected panic")
+					}
+				}()
+				s.Remove()
+			},
+		},
+		{
+			name: "clear",
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.Add(1)
+				s.Clear()
+				if !s.Empty() {
+					t.Errorf("expected empty")
+				}
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -48,14 +113,98 @@ func TestAdd(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			s := New[int]()
-			for _, item := range tc.items {
-				s.Add(item)
-			}
-			got := slices.Collect(s.All())
-			sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
-			if !slices.Equal(got, tc.want) {
-				t.Errorf("wrong slice value, got: %v, want: %v", got, tc.want)
-			}
+			tc.check(t, s)
+		})
+	}
+}
+
+func TestHashSet_BulkOperations(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		check func(*testing.T, *HashSet[int])
+	}{
+		{
+			name: "add_all",
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.AddAll(slices.Values([]int{1, 2, 3}))
+				if s.Size() != 3 {
+					t.Errorf("expected 3")
+				}
+			},
+		},
+		{
+			name: "contains_all",
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				
+				other := New[int]()
+				other.Add(1)
+				
+				if !s.ContainsAll(other) {
+					t.Errorf("expected true")
+				}
+				
+				other.Add(3)
+				if s.ContainsAll(other) {
+					t.Errorf("expected false")
+				}
+			},
+		},
+		{
+			name: "remove_all",
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.Add(3)
+				
+				other := New[int]()
+				other.Add(2)
+				other.Add(3)
+				
+				s.RemoveAll(other)
+				if s.Size() != 1 || !s.Contains(1) {
+					t.Errorf("expected only 1 to remain")
+				}
+			},
+		},
+		{
+			name: "retain_all",
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.Add(3)
+				
+				other := New[int]()
+				other.Add(2)
+				other.Add(4)
+				
+				s.RetainAll(other)
+				if s.Size() != 1 || !s.Contains(2) {
+					t.Errorf("expected only 2 to remain")
+				}
+			},
+		},
+		{
+			name: "iterators",
+			check: func(t *testing.T, s *HashSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				got := slices.Collect(s.All())
+				sort.Ints(got)
+				if !slices.Equal(got, []int{1, 2}) {
+					t.Errorf("wrong iter results")
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := New[int]()
+			tc.check(t, s)
 		})
 	}
 }


### PR DESCRIPTION
This PR fixes major bugs in the hashset package, implements missing performance options, and adds a comprehensive table-driven test suite.

**Fixes & Features:**
1. **Remove Bug:** `Remove()` previously returned an arbitrary element from the set but forgot to actually delete it from the underlying map. This is fixed.
2. **Remove Panic:** `Remove()` on an empty set now correctly panics instead of silently returning the zero value.
3. **RetainAll Bug:** `RetainAll()` was completely broken; its logic skipped elements missing from the target collection and accidentally did nothing to the set. It has been rewritten to cleanly intersect sets and safely swap the underlying map.
4. **Added Clear():** Added a `Clear()` function to instantly wipe the set.
5. **Added WithCapacity():** Added a configuration option to pre-allocate the capacity of the underlying `map`, enabling zero-allocation inserts when the final size is known.

**Testing:**
- Fully replaced the minimal tests with a massive table-driven test suite.
- Added a full benchmark suite to track throughput of insertions, lookups, and bulk operations.