### PR TITLE
fix(arraylist): resolve memory leak, complete stack interface, and add tests

### DIFF
--- a/arraylist/wrapper.go
+++ b/arraylist/wrapper.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-var _ collections.MutableList[int] = (*SliceWrapper[int])(nil)
+var (
+	_ collections.MutableList[int]  = (*SliceWrapper[int])(nil)
+	_ collections.MutableStack[int] = (*SliceWrapper[int])(nil)
+)
 
 type SliceWrapper[T any] struct {
 	slice []T
@@ -25,11 +28,14 @@ func (l *SliceWrapper[T]) Add(t T) {
 }
 
 func (l *SliceWrapper[T]) Remove() T {
-	if l.Empty() {
+	if len(l.slice) == 0 {
 		panic("cannot remove from an empty list")
 	}
-	t := l.slice[l.Size()-1]
-	l.slice = l.slice[0 : l.Size()-1]
+	idx := len(l.slice) - 1
+	t := l.slice[idx]
+	var zero T
+	l.slice[idx] = zero // avoid memory leak
+	l.slice = l.slice[:idx]
 	return t
 }
 
@@ -39,6 +45,22 @@ func (l *SliceWrapper[T]) Push(t T) {
 
 func (l *SliceWrapper[T]) Pop() T {
 	return l.Remove()
+}
+
+func (l *SliceWrapper[T]) Peek() T {
+	if len(l.slice) == 0 {
+		panic("cannot peek from an empty list")
+	}
+	return l.slice[len(l.slice)-1]
+}
+
+func (l *SliceWrapper[T]) Clear() {
+	// Zero out to avoid memory leaks
+	var zero T
+	for i := range l.slice {
+		l.slice[i] = zero
+	}
+	l.slice = l.slice[:0]
 }
 
 func (l *SliceWrapper[T]) AddAll(sequence iter.Seq[T]) {
@@ -52,7 +74,7 @@ func (l *SliceWrapper[T]) Size() int {
 }
 
 func (l *SliceWrapper[T]) Empty() bool {
-	return l.Size() == 0
+	return len(l.slice) == 0
 }
 
 func (l *SliceWrapper[T]) Get(index int) T {

--- a/arraylist/wrapper_bench_test.go
+++ b/arraylist/wrapper_bench_test.go
@@ -1,0 +1,50 @@
+package arraylist_test
+
+import (
+	"github.com/lock14/collections/arraylist"
+	"testing"
+)
+
+func BenchmarkSliceWrapper_Add(b *testing.B) {
+	l := arraylist.Wrap([]int{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Add(i)
+	}
+}
+
+func BenchmarkSliceWrapper_Remove(b *testing.B) {
+	l := arraylist.Wrap(make([]int, 0, b.N))
+	for i := 0; i < b.N; i++ {
+		l.Add(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Remove()
+	}
+}
+
+func BenchmarkSliceWrapper_Get(b *testing.B) {
+	l := arraylist.Wrap(make([]int, 1000))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Get(i % 1000)
+	}
+}
+
+func BenchmarkSliceWrapper_Set(b *testing.B) {
+	l := arraylist.Wrap(make([]int, 1000))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Set(i % 1000, i)
+	}
+}
+
+func BenchmarkSliceWrapper_IterateAll(b *testing.B) {
+	l := arraylist.Wrap(make([]int, 1000))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _ = range l.All() {
+		}
+	}
+}

--- a/arraylist/wrapper_test.go
+++ b/arraylist/wrapper_test.go
@@ -1,1 +1,180 @@
 package arraylist
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestWrap(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		slice []int
+		check func(*testing.T, *SliceWrapper[int])
+	}{
+		{
+			name:  "nil_slice",
+			slice: nil,
+			check: func(t *testing.T, l *SliceWrapper[int]) {
+				if !l.Empty() || l.Size() != 0 {
+					t.Errorf("expected empty list")
+				}
+			},
+		},
+		{
+			name:  "existing_slice",
+			slice: []int{1, 2, 3},
+			check: func(t *testing.T, l *SliceWrapper[int]) {
+				if l.Size() != 3 {
+					t.Errorf("expected size 3")
+				}
+				if l.Get(0) != 1 || l.Get(1) != 2 || l.Get(2) != 3 {
+					t.Errorf("wrong items")
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			l := Wrap(tc.slice)
+			tc.check(t, l)
+		})
+	}
+}
+
+func TestSliceWrapper_AddRemove(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		check func(*testing.T, *SliceWrapper[int])
+	}{
+		{
+			name: "add_and_remove",
+			check: func(t *testing.T, l *SliceWrapper[int]) {
+				l.Add(1)
+				l.Add(2)
+				if l.Size() != 2 {
+					t.Errorf("expected size 2")
+				}
+				if val := l.Remove(); val != 2 {
+					t.Errorf("expected 2, got %v", val)
+				}
+				if val := l.Remove(); val != 1 {
+					t.Errorf("expected 1, got %v", val)
+				}
+				if !l.Empty() {
+					t.Errorf("expected empty list")
+				}
+			},
+		},
+		{
+			name: "remove_empty_panic",
+			check: func(t *testing.T, l *SliceWrapper[int]) {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected panic")
+					}
+				}()
+				l.Remove()
+			},
+		},
+		{
+			name: "stack_methods",
+			check: func(t *testing.T, l *SliceWrapper[int]) {
+				l.Push(1)
+				l.Push(2)
+				if l.Peek() != 2 {
+					t.Errorf("expected 2")
+				}
+				if val := l.Pop(); val != 2 {
+					t.Errorf("expected 2")
+				}
+				if l.Peek() != 1 {
+					t.Errorf("expected 1")
+				}
+			},
+		},
+		{
+			name: "peek_empty_panic",
+			check: func(t *testing.T, l *SliceWrapper[int]) {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected panic")
+					}
+				}()
+				l.Peek()
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			l := Wrap([]int{})
+			tc.check(t, l)
+		})
+	}
+}
+
+func TestSliceWrapper_GetSet(t *testing.T) {
+	t.Parallel()
+	l := Wrap([]int{1, 2, 3})
+	if l.Get(1) != 2 {
+		t.Errorf("expected 2")
+	}
+	l.Set(1, 4)
+	if l.Get(1) != 4 {
+		t.Errorf("expected 4")
+	}
+}
+
+func TestSliceWrapper_BulkOperations(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		check func(*testing.T, *SliceWrapper[int])
+	}{
+		{
+			name: "add_all",
+			check: func(t *testing.T, l *SliceWrapper[int]) {
+				l.AddAll(slices.Values([]int{1, 2, 3}))
+				if l.Size() != 3 {
+					t.Errorf("expected 3")
+				}
+				if str := l.String(); str != "[1, 2, 3]" {
+					t.Errorf("expected [1, 2, 3], got %s", str)
+				}
+			},
+		},
+		{
+			name: "iterators",
+			check: func(t *testing.T, l *SliceWrapper[int]) {
+				l.AddAll(slices.Values([]int{1, 2, 3}))
+				got := slices.Collect(l.All())
+				if !slices.Equal(got, []int{1, 2, 3}) {
+					t.Errorf("expected [1, 2, 3], got %v", got)
+				}
+			},
+		},
+		{
+			name: "clear",
+			check: func(t *testing.T, l *SliceWrapper[int]) {
+				l.AddAll(slices.Values([]int{1, 2, 3}))
+				l.Clear()
+				if !l.Empty() {
+					t.Errorf("expected empty")
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			l := Wrap([]int{})
+			tc.check(t, l)
+		})
+	}
+}


### PR DESCRIPTION
This PR completes the review for the arraylist package wrapper and implements testing.

**Fixes & Features:**
1. **Memory Leak in `Remove`**: When an element was popped from the wrapper, the underlying slice was simply truncated but the actual array element wasn't zeroed out. This meant any pointers living in that array slot would be permanently retained by the slice, preventing garbage collection until the underlying array was discarded. This has been fixed to proactively zero out dropped elements.
2. **Missing `Peek`**: The wrapper implemented half of the stack interface (`Push` and `Pop`), but forgot to implement `Peek()`. This has been added so the wrapper now satisfies `MutableStack`.
3. **Added `Clear()`**: Added a `Clear()` function to cleanly wipe the array while zeroing out all elements to prevent memory leaks while retaining capacity.

**Testing:**
- The wrapper was entirely untested previously. Added a full table-driven test suite.
- Added a full benchmark suite to track throughput of append, pop, indexed get/set, and iteration operations.