### PR TITLE
feat(collections): add Clear() to MutableCollection and MutableMap interfaces

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -22,6 +22,7 @@ type MutableCollection[T any] interface {
 	Add(t T)
 	Remove() T
 	AddAll(iter.Seq[T])
+	Clear()
 }
 
 type List[T any] interface {
@@ -103,4 +104,5 @@ type MutableMap[K any, V any] interface {
 	Map[K, V]
 	Put(K, V)
 	Remove(K)
+	Clear()
 }


### PR DESCRIPTION
This PR finalizes the architectural design of the core `collections.go` interfaces.

**Features:**
- **`Clear()`:** During the review of the concrete collections (e.g. `linkedlist`, `hashmap`, `hashset`, `arraylist`, `arraydeque`, `heap`), we systematically added a `Clear()` function to quickly wipe the data structure while safely zeroing out internal elements to prevent memory leaks and retaining capacity where appropriate. Since every single mutable collection in the library now implements this, we've formally elevated `Clear()` into the `MutableCollection[T]` and `MutableMap[K, V]` interfaces.

**Review Notes:**
The architectural design here is actually very clever. By having `Peek()` dynamically alias to either `PeekFront()` or `PeekBack()` depending on whether the underlying implementation acts structurally like a stack (LIFO) or a queue (FIFO), you successfully avoid the classic diamond-inheritance `Peek()` conflict. This allows `Deque` implementations to smoothly serve as both Stacks and Queues while satisfying both interfaces seamlessly!