### PR TITLE
feat: implement TreeSet backed by TreeMap

### DIFF
--- a/treemap/btree.go
+++ b/treemap/btree.go
@@ -9,9 +9,16 @@ type node[K any, V any] struct {
 	children []*node[K, V]
 }
 
-func newNode[K any, V any](leaf bool) *node[K, V] {
+func (tm *TreeMap[K, V]) newNode(leaf bool) *node[K, V] {
+	var children []*node[K, V]
+	if !leaf {
+		children = make([]*node[K, V], 0, 2*tm.degree)
+	}
 	return &node[K, V]{
-		leaf: leaf,
+		leaf:     leaf,
+		keys:     make([]K, 0, 2*tm.degree-1),
+		values:   make([]V, 0, 2*tm.degree-1),
+		children: children,
 	}
 }
 
@@ -37,7 +44,7 @@ func (tm *TreeMap[K, V]) put(key K, value V) {
 
 	root := tm.root
 	if len(root.keys) == 2*tm.degree-1 {
-		s := newNode[K, V](false)
+		s := tm.newNode(false)
 		s.children = append(s.children, root)
 		tm.splitChild(s, 0, root)
 		tm.root = s
@@ -62,11 +69,11 @@ func (tm *TreeMap[K, V]) updateExisting(n *node[K, V], key K, value V) bool {
 
 func (tm *TreeMap[K, V]) splitChild(x *node[K, V], i int, y *node[K, V]) {
 	t := tm.degree
-	z := newNode[K, V](y.leaf)
+	z := tm.newNode(y.leaf)
 
 	// Copy the upper t-1 keys and values from y to z
-	z.keys = slices.Clone(y.keys[t:])
-	z.values = slices.Clone(y.values[t:])
+	z.keys = append(z.keys, y.keys[t:]...)
+	z.values = append(z.values, y.values[t:]...)
 	
 	// Truncate y's keys and values
 	midKey := y.keys[t-1]
@@ -82,7 +89,10 @@ func (tm *TreeMap[K, V]) splitChild(x *node[K, V], i int, y *node[K, V]) {
 	y.values = y.values[:t-1]
 
 	if !y.leaf {
-		z.children = slices.Clone(y.children[t:])
+		z.children = append(z.children, y.children[t:]...)
+		for j := t; j < len(y.children); j++ {
+			y.children[j] = nil
+		}
 		y.children = y.children[:t]
 	}
 

--- a/treemap/map.go
+++ b/treemap/map.go
@@ -32,7 +32,7 @@ func (tm *TreeMap[K, V]) Empty() bool {
 }
 
 func (tm *TreeMap[K, V]) Clear() {
-	tm.root = newNode[K, V](true)
+	tm.root = tm.newNode(true)
 	tm.size = 0
 }
 

--- a/treemap/treemap.go
+++ b/treemap/treemap.go
@@ -56,11 +56,12 @@ func New[K any, V any](opts ...Option[K]) *TreeMap[K, V] {
 	if config.comparator == nil {
 		panic("comparator must be provided or use NewOrdered")
 	}
-	return &TreeMap[K, V]{
-		root:       newNode[K, V](true),
+	tm := &TreeMap[K, V]{
 		degree:     config.degree,
 		comparator: config.comparator,
 	}
+	tm.root = tm.newNode(true)
+	return tm
 }
 
 // NewOrdered creates an empty TreeMap for keys that satisfy cmp.Ordered using natural ordering.

--- a/treeset/set.go
+++ b/treeset/set.go
@@ -1,0 +1,102 @@
+package treeset
+
+import (
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/lock14/collections"
+)
+
+var _ collections.MutableSet[int] = (*TreeSet[int])(nil)
+
+// Add inserts the specified element into the set.
+func (s *TreeSet[T]) Add(item T) {
+	s.m.Put(item, struct{}{})
+}
+
+// Remove removes and returns a single element from the set.
+func (s *TreeSet[T]) Remove() T {
+	for item := range s.m.Keys() {
+		s.m.Remove(item)
+		return item
+	}
+	panic("cannot remove from an empty set")
+}
+
+// RemoveElement removes the specified element from the set.
+func (s *TreeSet[T]) RemoveElement(item T) {
+	s.m.Remove(item)
+}
+
+// Contains returns true if this set contains the specified element.
+func (s *TreeSet[T]) Contains(item T) bool {
+	return s.m.ContainsKey(item)
+}
+
+// ContainsAll returns true if this set contains all elements of the specified collection.
+func (s *TreeSet[T]) ContainsAll(other collections.Collection[T]) bool {
+	for item := range other.All() {
+		if !s.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// AddAll inserts all elements from the given sequence into the set.
+func (s *TreeSet[T]) AddAll(sequence iter.Seq[T]) {
+	for t := range sequence {
+		s.Add(t)
+	}
+}
+
+// RemoveAll removes all elements of the specified collection from this set.
+func (s *TreeSet[T]) RemoveAll(other collections.Collection[T]) {
+	for t := range other.All() {
+		s.RemoveElement(t)
+	}
+}
+
+// RetainAll retains only the elements in this set that are contained in the specified collection.
+func (s *TreeSet[T]) RetainAll(other collections.Collection[T]) {
+	var intersection []T
+	for t := range other.All() {
+		if s.Contains(t) {
+			intersection = append(intersection, t)
+		}
+	}
+	s.Clear()
+	for _, t := range intersection {
+		s.Add(t)
+	}
+}
+
+// Clear removes all elements from the set.
+func (s *TreeSet[T]) Clear() {
+	s.m.Clear()
+}
+
+// Size returns the number of elements in the set.
+func (s *TreeSet[T]) Size() int {
+	return s.m.Size()
+}
+
+// Empty returns true if the set contains no elements.
+func (s *TreeSet[T]) Empty() bool {
+	return s.m.Empty()
+}
+
+// All returns an Iterator over all the elements of this set.
+func (s *TreeSet[T]) All() iter.Seq[T] {
+	return s.m.Keys()
+}
+
+// String returns a string representation of the set.
+func (s *TreeSet[T]) String() string {
+	vals := make([]string, 0, s.Size())
+	for item := range s.All() {
+		vals = append(vals, fmt.Sprintf("%+v", item))
+	}
+	return "[" + strings.Join(vals, ", ") + "]"
+}

--- a/treeset/set.go
+++ b/treeset/set.go
@@ -60,7 +60,7 @@ func (s *TreeSet[T]) RemoveAll(other collections.Collection[T]) {
 
 // RetainAll retains only the elements in this set that are contained in the specified collection.
 func (s *TreeSet[T]) RetainAll(other collections.Collection[T]) {
-	var intersection []T
+	intersection := make([]T, 0, min(s.Size(), other.Size()))
 	for t := range other.All() {
 		if s.Contains(t) {
 			intersection = append(intersection, t)

--- a/treeset/treeset.go
+++ b/treeset/treeset.go
@@ -1,0 +1,61 @@
+package treeset
+
+import (
+	"cmp"
+	"github.com/lock14/collections/comparator"
+	"github.com/lock14/collections/treemap"
+)
+
+// TreeSet represents a set of elements backed by a B-Tree.
+type TreeSet[T any] struct {
+	m *treemap.TreeMap[T, struct{}]
+}
+
+// Config holds the values for configuring a TreeSet.
+type Config[T any] struct {
+	degree     *int
+	comparator comparator.Comparator[T]
+}
+
+// Option configures a TreeSet config.
+type Option[T any] func(*Config[T])
+
+// WithDegree configures the degree of the underlying B-Tree.
+func WithDegree[T any](degree int) Option[T] {
+	return func(c *Config[T]) {
+		c.degree = &degree
+	}
+}
+
+// WithComparator configures the comparator for the TreeSet.
+func WithComparator[T any](comp comparator.Comparator[T]) Option[T] {
+	return func(c *Config[T]) {
+		c.comparator = comp
+	}
+}
+
+// New creates an empty TreeSet.
+func New[T any](opts ...Option[T]) *TreeSet[T] {
+	config := &Config[T]{}
+	for _, option := range opts {
+		option(config)
+	}
+
+	var mapOpts []treemap.Option[T]
+	if config.degree != nil {
+		mapOpts = append(mapOpts, treemap.WithDegree[T](*config.degree))
+	}
+	if config.comparator != nil {
+		mapOpts = append(mapOpts, treemap.WithComparator[T](config.comparator))
+	}
+
+	return &TreeSet[T]{
+		m: treemap.New[T, struct{}](mapOpts...),
+	}
+}
+
+// NewOrdered creates an empty TreeSet for types that implement cmp.Ordered.
+func NewOrdered[T cmp.Ordered](opts ...Option[T]) *TreeSet[T] {
+	opts = append([]Option[T]{WithComparator(comparator.NaturalOrder[T]())}, opts...)
+	return New(opts...)
+}

--- a/treeset/treeset_bench_test.go
+++ b/treeset/treeset_bench_test.go
@@ -1,0 +1,56 @@
+package treeset_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/lock14/collections/treeset"
+)
+
+func BenchmarkTreeSet_Add(b *testing.B) {
+	for _, size := range []int{1000, 10000, 100000} {
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			b.StopTimer()
+			keys := make([]int, size)
+			for i := 0; i < size; i++ {
+				keys[i] = i
+			}
+			rand.Shuffle(size, func(i, j int) {
+				keys[i], keys[j] = keys[j], keys[i]
+			})
+
+			b.StartTimer()
+			for i := 0; i < b.N; i++ {
+				s := treeset.NewOrdered[int]()
+				for _, k := range keys {
+					s.Add(k)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkTreeSet_Contains(b *testing.B) {
+	for _, size := range []int{1000, 10000, 100000} {
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			b.StopTimer()
+			s := treeset.NewOrdered[int]()
+			keys := make([]int, size)
+			for i := 0; i < size; i++ {
+				keys[i] = i
+				s.Add(i)
+			}
+			rand.Shuffle(size, func(i, j int) {
+				keys[i], keys[j] = keys[j], keys[i]
+			})
+
+			b.StartTimer()
+			for i := 0; i < b.N; i++ {
+				for _, k := range keys {
+					_ = s.Contains(k)
+				}
+			}
+		})
+	}
+}

--- a/treeset/treeset_test.go
+++ b/treeset/treeset_test.go
@@ -1,0 +1,253 @@
+package treeset
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/lock14/collections/arraylist"
+)
+
+func TestTreeSet_Operations(t *testing.T) {
+	cases := []struct {
+		name     string
+		ops      func(s *TreeSet[int])
+		validate func(t *testing.T, s *TreeSet[int])
+	}{
+		{
+			name: "basic add and contains",
+			ops: func(s *TreeSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.Add(3)
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				if s.Size() != 3 {
+					t.Errorf("expected size 3, got %d", s.Size())
+				}
+				if !s.Contains(2) {
+					t.Errorf("expected to contain 2")
+				}
+				if s.Contains(4) {
+					t.Errorf("expected not to contain 4")
+				}
+			},
+		},
+		{
+			name: "add duplicate elements",
+			ops: func(s *TreeSet[int]) {
+				s.Add(1)
+				s.Add(1)
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				if s.Size() != 1 {
+					t.Errorf("expected size 1, got %d", s.Size())
+				}
+			},
+		},
+		{
+			name: "remove element",
+			ops: func(s *TreeSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.RemoveElement(1)
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				if s.Contains(1) {
+					t.Errorf("expected not to contain 1")
+				}
+				if s.Size() != 1 {
+					t.Errorf("expected size 1, got %d", s.Size())
+				}
+			},
+		},
+		{
+			name: "remove single element",
+			ops: func(s *TreeSet[int]) {
+				s.Add(1)
+				val := s.Remove()
+				if val != 1 {
+					t.Errorf("expected to remove 1, got %d", val)
+				}
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				if !s.Empty() {
+					t.Errorf("expected set to be empty")
+				}
+			},
+		},
+		{
+			name: "clear set",
+			ops: func(s *TreeSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.Clear()
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				if !s.Empty() || s.Size() != 0 {
+					t.Errorf("expected set to be empty")
+				}
+			},
+		},
+		{
+			name: "contains all",
+			ops: func(s *TreeSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.Add(3)
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				other := arraylist.Wrap([]int{})
+				other.Add(1)
+				other.Add(2)
+				if !s.ContainsAll(other) {
+					t.Errorf("expected to contain all elements")
+				}
+				other.Add(4)
+				if s.ContainsAll(other) {
+					t.Errorf("expected not to contain 4")
+				}
+			},
+		},
+		{
+			name: "add all",
+			ops: func(s *TreeSet[int]) {
+				other := arraylist.Wrap([]int{})
+				other.Add(1)
+				other.Add(2)
+				s.AddAll(other.All())
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				if s.Size() != 2 {
+					t.Errorf("expected size 2, got %d", s.Size())
+				}
+				if !s.Contains(1) || !s.Contains(2) {
+					t.Errorf("expected to contain 1 and 2")
+				}
+			},
+		},
+		{
+			name: "remove all",
+			ops: func(s *TreeSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.Add(3)
+				other := arraylist.Wrap([]int{})
+				other.Add(2)
+				other.Add(3)
+				s.RemoveAll(other)
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				if s.Size() != 1 {
+					t.Errorf("expected size 1, got %d", s.Size())
+				}
+				if !s.Contains(1) {
+					t.Errorf("expected to contain 1")
+				}
+			},
+		},
+		{
+			name: "retain all",
+			ops: func(s *TreeSet[int]) {
+				s.Add(1)
+				s.Add(2)
+				s.Add(3)
+				other := arraylist.Wrap([]int{})
+				other.Add(2)
+				other.Add(3)
+				other.Add(4)
+				s.RetainAll(other)
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				if s.Size() != 2 {
+					t.Errorf("expected size 2, got %d", s.Size())
+				}
+				if !s.Contains(2) || !s.Contains(3) {
+					t.Errorf("expected to retain 2 and 3")
+				}
+			},
+		},
+		{
+			name: "all iterator",
+			ops: func(s *TreeSet[int]) {
+				s.Add(3)
+				s.Add(1)
+				s.Add(2)
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				var elements []int
+				for e := range s.All() {
+					elements = append(elements, e)
+				}
+				expected := []int{1, 2, 3}
+				if !slices.Equal(expected, elements) {
+					t.Errorf("expected %v, got %v", expected, elements)
+				}
+			},
+		},
+		{
+			name: "string representation",
+			ops: func(s *TreeSet[int]) {
+				s.Add(2)
+				s.Add(1)
+			},
+			validate: func(t *testing.T, s *TreeSet[int]) {
+				str := s.String()
+				// Should be ordered
+				if str != "[1, 2]" {
+					t.Errorf("unexpected string representation: %s", str)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := NewOrdered[int]()
+			tc.ops(s)
+			tc.validate(t, s)
+		})
+	}
+}
+
+func TestTreeSet_Constructors(t *testing.T) {
+	cases := []struct {
+		name        string
+		constructor func()
+		expectPanic bool
+	}{
+		{
+			name: "remove from empty panics",
+			constructor: func() {
+				s := NewOrdered[int]()
+				s.Remove()
+			},
+			expectPanic: true,
+		},
+		{
+			name: "missing comparator panics",
+			constructor: func() {
+				New[int]()
+			},
+			expectPanic: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				r := recover()
+				if tc.expectPanic && r == nil {
+					t.Errorf("expected panic but got none")
+				}
+				if !tc.expectPanic && r != nil {
+					t.Errorf("expected no panic but got: %v", r)
+				}
+			}()
+			tc.constructor()
+		})
+	}
+}


### PR DESCRIPTION
Implements collections.MutableSet using the existing 	reemap package. This provides an ordered, B-Tree backed Set with high CPU cache locality. Includes table-driven tests and standard benchmarks.