### PR TITLE
style: apply gofmt -s to entire codebase

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,15 @@ jobs:
         with:
           go-version: '${{ env.GO_VERSION }}'
 
+      - name: Check Formatting
+        run: |
+          if [ -n "$(gofmt -s -l .)" ]; then
+            echo "The following files are not formatted properly:"
+            gofmt -s -l .
+            echo "Please run 'gofmt -s -w .' locally and commit the changes."
+            exit 1
+          fi
+
       - name: Build
         run: go build -v ./...
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 
 coverage.out
+coverage

--- a/arraydeque/arraydeque_bench_test.go
+++ b/arraydeque/arraydeque_bench_test.go
@@ -61,7 +61,7 @@ func BenchmarkArrayDeque_IterateAll(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _ = range d.All() {
+		for range d.All() {
 		}
 	}
 }
@@ -73,7 +73,7 @@ func BenchmarkArrayDeque_IterateBackward(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _ = range d.Backward() {
+		for range d.Backward() {
 		}
 	}
 }

--- a/arraylist/arraylist_bench_test.go
+++ b/arraylist/arraylist_bench_test.go
@@ -36,7 +36,7 @@ func BenchmarkSliceWrapper_Set(b *testing.B) {
 	l := arraylist.Wrap(make([]int, 1000))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Set(i % 1000, i)
+		l.Set(i%1000, i)
 	}
 }
 
@@ -44,7 +44,7 @@ func BenchmarkSliceWrapper_IterateAll(b *testing.B) {
 	l := arraylist.Wrap(make([]int, 1000))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _ = range l.All() {
+		for range l.All() {
 		}
 	}
 }

--- a/bitset/bitset_bench_test.go
+++ b/bitset/bitset_bench_test.go
@@ -73,7 +73,7 @@ func BenchmarkSetBits_Sparse(b *testing.B) {
 	bs.Set(0)
 	bs.Set(5)
 	bs.Set(63)
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for range bs.SetBits() {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -181,7 +181,7 @@ func (g *Graph[V]) String() string {
 			}
 			seen[edgePair{u, v}] = true
 		}
-		
+
 		if !first {
 			sb.WriteString(", ")
 		}

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -127,7 +127,7 @@ func TestGraph_Iterators(t *testing.T) {
 	if !slices.Equal(preds, []int{1}) {
 		t.Errorf("unexpected predecessors")
 	}
-	
+
 	neighs := slices.Collect(g.Neighbors(2))
 	if !slices.Equal(neighs, []int{3}) {
 		t.Errorf("unexpected neighbors")
@@ -138,7 +138,9 @@ func TestGraph_Iterators(t *testing.T) {
 		edges = append(edges, edge{u, v})
 	}
 	slices.SortFunc(edges, func(a, b edge) int {
-		if a.u != b.u { return a.u - b.u }
+		if a.u != b.u {
+			return a.u - b.u
+		}
 		return a.v - b.v
 	})
 	if !slices.Equal(edges, []edge{{1, 2}, {2, 3}}) {
@@ -150,13 +152,15 @@ func TestGraph_Iterators(t *testing.T) {
 		incident = append(incident, edge{u, v})
 	}
 	slices.SortFunc(incident, func(a, b edge) int {
-		if a.u != b.u { return a.u - b.u }
+		if a.u != b.u {
+			return a.u - b.u
+		}
 		return a.v - b.v
 	})
 	if !slices.Equal(incident, []edge{{1, 2}, {2, 3}}) {
 		t.Errorf("unexpected incident edges")
 	}
-	
+
 	var inIncident []edge
 	for u, v := range g.InIncidentEdges(2) {
 		inIncident = append(inIncident, edge{u, v})
@@ -164,7 +168,7 @@ func TestGraph_Iterators(t *testing.T) {
 	if !slices.Equal(inIncident, []edge{{1, 2}}) {
 		t.Errorf("unexpected in-incident edges")
 	}
-	
+
 	var outIncident []edge
 	for u, v := range g.OutIncidentEdges(2) {
 		outIncident = append(outIncident, edge{u, v})
@@ -202,14 +206,14 @@ func TestGraph_Equal(t *testing.T) {
 	t.Parallel()
 	g1 := New[int]()
 	g1.AddEdge(1, 2)
-	
+
 	g2 := New[int]()
 	g2.AddEdge(1, 2)
-	
+
 	if !g1.Equal(g2) {
 		t.Errorf("expected equal")
 	}
-	
+
 	g2.AddEdge(2, 3)
 	if g1.Equal(g2) {
 		t.Errorf("expected not equal")
@@ -218,7 +222,7 @@ func TestGraph_Equal(t *testing.T) {
 
 func TestGraph_String(t *testing.T) {
 	t.Parallel()
-	
+
 	g1 := New[int](Directed())
 	g1.AddEdge(1, 2)
 	g1.AddVertex(3)
@@ -229,7 +233,7 @@ func TestGraph_String(t *testing.T) {
 	if strings.Contains(str1, "{}") {
 		t.Errorf("unexpected void struct in string: %s", str1)
 	}
-	
+
 	g2 := New[int]()
 	g2.AddEdge(1, 2)
 	str2 := g2.String()
@@ -239,7 +243,7 @@ func TestGraph_String(t *testing.T) {
 }
 
 func TestGraph_Coverage(t *testing.T) {
-    g := New[int]()
-    g.AddEdge(1, 2)
-    _ = g.String()
+	g := New[int]()
+	g.AddEdge(1, 2)
+	_ = g.String()
 }

--- a/hashmap/hashmap_bench_test.go
+++ b/hashmap/hashmap_bench_test.go
@@ -50,7 +50,7 @@ func BenchmarkHashMap_IterateAll(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _, _ = range hm.All() {
+		for range hm.All() {
 		}
 	}
 }

--- a/hashmap/hashmap_test.go
+++ b/hashmap/hashmap_test.go
@@ -66,7 +66,7 @@ func TestHashMap_Operations(t *testing.T) {
 				hm.Put(1, "a")
 				hm.Put(2, "b")
 				hm.Put(1, "c") // overwrite
-				
+
 				if hm.Size() != 2 {
 					t.Errorf("expected size 2")
 				}
@@ -87,7 +87,7 @@ func TestHashMap_Operations(t *testing.T) {
 				hm.Put(1, "a")
 				hm.Remove(1)
 				hm.Remove(2) // non-existent
-				
+
 				if !hm.Empty() {
 					t.Errorf("expected empty")
 				}
@@ -98,7 +98,7 @@ func TestHashMap_Operations(t *testing.T) {
 			check: func(t *testing.T, hm *HashMap[int, string]) {
 				hm.Put(1, "a")
 				hm.Clear()
-				
+
 				if hm.Size() != 0 {
 					t.Errorf("expected empty")
 				}
@@ -109,13 +109,13 @@ func TestHashMap_Operations(t *testing.T) {
 			check: func(t *testing.T, hm *HashMap[int, string]) {
 				hm.Put(1, "a")
 				hm.Put(2, "b")
-				
+
 				keys := slices.Collect(hm.Keys())
 				sort.Ints(keys)
 				if !slices.Equal(keys, []int{1, 2}) {
 					t.Errorf("keys wrong")
 				}
-				
+
 				vals := slices.Collect(hm.Values())
 				sort.Strings(vals)
 				if !slices.Equal(vals, []string{"a", "b"}) {
@@ -128,7 +128,7 @@ func TestHashMap_Operations(t *testing.T) {
 			check: func(t *testing.T, hm *HashMap[int, string]) {
 				hm.Put(1, "a")
 				hm.Put(2, "b")
-				
+
 				var keys []int
 				var vals []string
 				for k, v := range hm.All() {

--- a/hashset/hashset_test.go
+++ b/hashset/hashset_test.go
@@ -138,14 +138,14 @@ func TestHashSet_BulkOperations(t *testing.T) {
 			check: func(t *testing.T, s *HashSet[int]) {
 				s.Add(1)
 				s.Add(2)
-				
+
 				other := New[int]()
 				other.Add(1)
-				
+
 				if !s.ContainsAll(other) {
 					t.Errorf("expected true")
 				}
-				
+
 				other.Add(3)
 				if s.ContainsAll(other) {
 					t.Errorf("expected false")
@@ -158,11 +158,11 @@ func TestHashSet_BulkOperations(t *testing.T) {
 				s.Add(1)
 				s.Add(2)
 				s.Add(3)
-				
+
 				other := New[int]()
 				other.Add(2)
 				other.Add(3)
-				
+
 				s.RemoveAll(other)
 				if s.Size() != 1 || !s.Contains(1) {
 					t.Errorf("expected only 1 to remain")
@@ -175,11 +175,11 @@ func TestHashSet_BulkOperations(t *testing.T) {
 				s.Add(1)
 				s.Add(2)
 				s.Add(3)
-				
+
 				other := New[int]()
 				other.Add(2)
 				other.Add(4)
-				
+
 				s.RetainAll(other)
 				if s.Size() != 1 || !s.Contains(2) {
 					t.Errorf("expected only 2 to remain")

--- a/heap/heap_bench_test.go
+++ b/heap/heap_bench_test.go
@@ -58,7 +58,7 @@ func BenchmarkHeap_IterateAll(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _ = range h.All() {
+		for range h.All() {
 		}
 	}
 }

--- a/heap/heap_test.go
+++ b/heap/heap_test.go
@@ -246,5 +246,5 @@ func TestHeap_Coverage(t *testing.T) {
 		f()
 	}
 	assertPanics(func() { h.Remove() })
-    _ = comparator.NaturalOrder[int]()(1, 2)
+	_ = comparator.NaturalOrder[int]()(1, 2)
 }

--- a/labeledgraph/labeledgraph.go
+++ b/labeledgraph/labeledgraph.go
@@ -397,7 +397,7 @@ func (g *LabeledGraph[V, L]) String() string {
 			}
 			seen[edgePair{u, v}] = true
 		}
-		
+
 		if !first {
 			sb.WriteString(", ")
 		}

--- a/labeledgraph/labeledgraph_bench_test.go
+++ b/labeledgraph/labeledgraph_bench_test.go
@@ -58,7 +58,7 @@ func BenchmarkLabeledGraph_IterateVertices(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _ = range g.Vertices() {
+		for range g.Vertices() {
 		}
 	}
 }
@@ -70,7 +70,7 @@ func BenchmarkLabeledGraph_IterateEdges(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _, _ = range g.Edges() {
+		for range g.Edges() {
 		}
 	}
 }
@@ -82,7 +82,7 @@ func BenchmarkLabeledGraph_IncidentEdges(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _, _ = range g.IncidentEdges(0) {
+		for range g.IncidentEdges(0) {
 		}
 	}
 }

--- a/labeledgraph/labeledgraph_test.go
+++ b/labeledgraph/labeledgraph_test.go
@@ -259,7 +259,7 @@ func TestLabeledGraph_Degree(t *testing.T) {
 				g.AddEdge(2, 1, "2->1")
 				g.AddEdge(1, 3, "1->3")
 				g.AddEdge(1, 1, "1->1") // self loop
-				
+
 				if deg, ok := g.Degree(1); !ok || deg != 5 { // 3 out, 1 in (wait: 2->1 in, 1->1 in; 1->2 out, 1->3 out, 1->1 out)
 					// Let's count properly: In: 2->1, 1->1 (2). Out: 1->2, 1->3, 1->1 (3). Total 5.
 					t.Errorf("expected degree 5, got %d", deg)
@@ -278,7 +278,7 @@ func TestLabeledGraph_Degree(t *testing.T) {
 				g.AddEdge(1, 2, "1-2")
 				g.AddEdge(1, 3, "1-3")
 				g.AddEdge(1, 1, "1-1") // self loop
-				
+
 				if deg, ok := g.Degree(1); !ok || deg != 3 {
 					t.Errorf("expected degree 3, got %d", deg)
 				}
@@ -315,7 +315,7 @@ func TestLabeledGraph_Degree(t *testing.T) {
 	}
 }
 
-type edge struct { u, v int }
+type edge struct{ u, v int }
 
 func TestLabeledGraph_Iterators(t *testing.T) {
 	t.Parallel()
@@ -351,14 +351,14 @@ func TestLabeledGraph_Iterators(t *testing.T) {
 				if !slices.Equal(got, want) {
 					t.Errorf("expected successors %v, got %v", want, got)
 				}
-				
+
 				gotPreds := slices.Collect(g.Predecessors(1))
 				slices.Sort(gotPreds)
 				wantPreds := []int{4}
 				if !slices.Equal(gotPreds, wantPreds) {
 					t.Errorf("expected predecessors %v, got %v", wantPreds, gotPreds)
 				}
-				
+
 				if len(slices.Collect(g.Successors(99))) != 0 {
 					t.Errorf("expected empty iterator for missing vertex")
 				}
@@ -374,13 +374,15 @@ func TestLabeledGraph_Iterators(t *testing.T) {
 				g.AddEdge(1, 2, "")
 				g.AddEdge(2, 3, "")
 				g.AddEdge(4, 2, "")
-				
+
 				var edges []edge
 				for u, v := range g.Edges() {
 					edges = append(edges, edge{u, v})
 				}
 				slices.SortFunc(edges, func(a, b edge) int {
-					if a.u != b.u { return a.u - b.u }
+					if a.u != b.u {
+						return a.u - b.u
+					}
 					return a.v - b.v
 				})
 				wantEdges := []edge{{1, 2}, {2, 3}, {4, 2}}
@@ -393,7 +395,9 @@ func TestLabeledGraph_Iterators(t *testing.T) {
 					incident = append(incident, edge{u, v})
 				}
 				slices.SortFunc(incident, func(a, b edge) int {
-					if a.u != b.u { return a.u - b.u }
+					if a.u != b.u {
+						return a.u - b.u
+					}
 					return a.v - b.v
 				})
 				wantIncident := []edge{{1, 2}, {2, 3}, {4, 2}}
@@ -470,12 +474,12 @@ func TestLabeledGraph_Clone(t *testing.T) {
 			check: func(t *testing.T, g *LabeledGraph[int, string]) {
 				g.AddEdge(1, 2, "1->2")
 				g.AddVertex(3)
-				
+
 				clone := g.Clone()
 				if clone.Order() != 3 || clone.Size() != 1 {
 					t.Errorf("clone has wrong order/size")
 				}
-				
+
 				// Mutate original, should not affect clone
 				g.AddEdge(2, 3, "2->3")
 				if clone.Size() != 1 {
@@ -507,17 +511,17 @@ func TestLabeledGraph_Equal(t *testing.T) {
 			check: func(t *testing.T, g *LabeledGraph[int, string]) {
 				g.AddEdge(1, 2, "A")
 				g.AddVertex(3)
-				
+
 				other := New[int, string](Directed())
 				other.AddEdge(1, 2, "A")
 				other.AddVertex(3)
-				
+
 				eqFunc := func(a, b string) bool { return a == b }
-				
+
 				if !g.Equal(other, eqFunc) {
 					t.Errorf("expected graphs to be equal")
 				}
-				
+
 				other.AddEdge(2, 3, "B")
 				if g.Equal(other, eqFunc) {
 					t.Errorf("expected graphs to not be equal")
@@ -580,47 +584,63 @@ func TestLabeledGraph_String(t *testing.T) {
 }
 
 func TestLabeledGraph_Coverage(t *testing.T) {
-    g := New[int, int]()
-    g.AddEdge(1, 2, 3)
-    for _ = range g.Successors(1) { break }
-    for _ = range g.Predecessors(2) { break }
-    for _ = range g.Edges() { break }
-    for _ = range g.IncidentEdges(1) { break }
-    for _ = range g.InIncidentEdges(2) { break }
-    for _ = range g.OutIncidentEdges(1) { break }
-    
-    g2 := New[int, int]()
-    g2.AddEdge(1, 2, 10)
-    g2.AddEdge(1, 4, 40)
-    _ = g.Equal(g2, func(a, b int) bool { return a == b })
-    _ = g.String()
-    _ = g.Clone()
+	g := New[int, int]()
+	g.AddEdge(1, 2, 3)
+	for range g.Successors(1) {
+		break
+	}
+	for range g.Predecessors(2) {
+		break
+	}
+	for range g.Edges() {
+		break
+	}
+	for range g.IncidentEdges(1) {
+		break
+	}
+	for range g.InIncidentEdges(2) {
+		break
+	}
+	for range g.OutIncidentEdges(1) {
+		break
+	}
 
-    un := &undirectedNodeData[int, int]{adjacentLabels: make(map[int]int)}
-    un.setPredecessorLabel(2, 20)
-    un.setSuccessorLabel(3, 30)
-    _ = un.containsPredecessor(2)
-    
-    d := New[int, int](Directed())
-    d.AddEdge(1, 2, 10)
-    _ = d.graph[2].containsPredecessor(1)
-    
-    // cover directedNodeData setters
-    dn := &directedNodeData[int, int]{successorLabels: make(map[int]int)}
-    dn.setPredecessorLabel(2, 20)
-    dn.setSuccessorLabel(3, 30)
-    
-    // cover undirected Edges/IncidentEdges early break
-    for _ = range g.Edges() { break }
-    for _ = range g.IncidentEdges(1) { break }
-    
-    // cover equal early returns
-    g3 := New[int, int]()
-    g3.AddEdge(1, 2, 10)
-    g4 := New[int, int]()
-    g4.AddEdge(1, 3, 10)
-    _ = g3.Equal(g4, func(a, b int) bool { return a == b })
-    
-    g5 := New[int, int](Directed())
-    _ = g3.Equal(g5, func(a, b int) bool { return a == b })
+	g2 := New[int, int]()
+	g2.AddEdge(1, 2, 10)
+	g2.AddEdge(1, 4, 40)
+	_ = g.Equal(g2, func(a, b int) bool { return a == b })
+	_ = g.String()
+	_ = g.Clone()
+
+	un := &undirectedNodeData[int, int]{adjacentLabels: make(map[int]int)}
+	un.setPredecessorLabel(2, 20)
+	un.setSuccessorLabel(3, 30)
+	_ = un.containsPredecessor(2)
+
+	d := New[int, int](Directed())
+	d.AddEdge(1, 2, 10)
+	_ = d.graph[2].containsPredecessor(1)
+
+	// cover directedNodeData setters
+	dn := &directedNodeData[int, int]{successorLabels: make(map[int]int)}
+	dn.setPredecessorLabel(2, 20)
+	dn.setSuccessorLabel(3, 30)
+
+	// cover undirected Edges/IncidentEdges early break
+	for range g.Edges() {
+		break
+	}
+	for range g.IncidentEdges(1) {
+		break
+	}
+
+	// cover equal early returns
+	g3 := New[int, int]()
+	g3.AddEdge(1, 2, 10)
+	g4 := New[int, int]()
+	g4.AddEdge(1, 3, 10)
+	_ = g3.Equal(g4, func(a, b int) bool { return a == b })
+
+	g5 := New[int, int](Directed())
+	_ = g3.Equal(g5, func(a, b int) bool { return a == b })
 }

--- a/linkedhashmap/linkedhashmap_bench_test.go
+++ b/linkedhashmap/linkedhashmap_bench_test.go
@@ -72,7 +72,7 @@ func BenchmarkLinkedHashMap_IterateAll(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _ = range m.All() {
+		for range m.All() {
 		}
 	}
 }

--- a/linkedhashmap/linkedhashmap_test.go
+++ b/linkedhashmap/linkedhashmap_test.go
@@ -103,7 +103,7 @@ func TestLinkedHashMap_Get(t *testing.T) {
 				if !ok || val != 10 {
 					t.Errorf("expected 10")
 				}
-				
+
 				keys := slices.Collect(m.Keys())
 				if !slices.Equal(keys, []int{1, 2}) {
 					t.Errorf("expected [1, 2], got %v", keys)
@@ -120,7 +120,7 @@ func TestLinkedHashMap_Get(t *testing.T) {
 				if !ok || val != 10 {
 					t.Errorf("expected 10")
 				}
-				
+
 				// 1 should now be the most recently accessed (at the tail)
 				keys := slices.Collect(m.Keys())
 				if !slices.Equal(keys, []int{2, 1}) {

--- a/linkedlist/linkedlist.go
+++ b/linkedlist/linkedlist.go
@@ -183,5 +183,3 @@ func unlink[T any](n *node[T]) {
 	n.prev = nil
 	n.next = nil
 }
-
-

--- a/linkedlist/linkedlist_bench_test.go
+++ b/linkedlist/linkedlist_bench_test.go
@@ -61,7 +61,7 @@ func BenchmarkLinkedList_IterateAll(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _ = range l.All() {
+		for range l.All() {
 		}
 	}
 }

--- a/linkedlist/linkedlist_test.go
+++ b/linkedlist/linkedlist_test.go
@@ -91,7 +91,7 @@ func TestLinkedList_GetSet(t *testing.T) {
 				l.AddBack(10)
 				l.AddBack(20)
 				l.AddBack(30)
-				
+
 				if val := l.Get(0); val != 10 {
 					t.Errorf("expected 10, got %d", val)
 				}
@@ -108,7 +108,7 @@ func TestLinkedList_GetSet(t *testing.T) {
 			check: func(t *testing.T, l *LinkedList[int]) {
 				l.AddBack(10)
 				l.AddBack(20)
-				
+
 				l.Set(1, 100)
 				if val := l.Get(1); val != 100 {
 					t.Errorf("expected 100, got %d", val)

--- a/treemap/btree.go
+++ b/treemap/btree.go
@@ -74,11 +74,11 @@ func (tm *TreeMap[K, V]) splitChild(x *node[K, V], i int, y *node[K, V]) {
 	// Copy the upper t-1 keys and values from y to z
 	z.keys = append(z.keys, y.keys[t:]...)
 	z.values = append(z.values, y.values[t:]...)
-	
+
 	// Truncate y's keys and values
 	midKey := y.keys[t-1]
 	midVal := y.values[t-1]
-	
+
 	var zeroK K
 	var zeroV V
 	for j := t - 1; j < len(y.keys); j++ {
@@ -176,7 +176,7 @@ func (tm *TreeMap[K, V]) deleteNode(x *node[K, V], key K) {
 		if x.leaf {
 			return
 		}
-		
+
 		// Ensure the child we descend into has at least t keys
 		if len(x.children[i].keys) == t-1 {
 			tm.fill(x, i)

--- a/treemap/map.go
+++ b/treemap/map.go
@@ -71,7 +71,7 @@ func (tm *TreeMap[K, V]) inOrder(n *node[K, V], yield func(K, V) bool) bool {
 
 func (tm *TreeMap[K, V]) Keys() iter.Seq[K] {
 	return func(yield func(K) bool) {
-		for k, _ := range tm.All() {
+		for k := range tm.All() {
 			if !yield(k) {
 				return
 			}

--- a/treemap/treemap_bench_test.go
+++ b/treemap/treemap_bench_test.go
@@ -2,9 +2,9 @@ package treemap_test
 
 import (
 	"fmt"
+	"github.com/lock14/collections/treemap"
 	"math/rand"
 	"testing"
-	"github.com/lock14/collections/treemap"
 )
 
 func BenchmarkTreeMap_Put(b *testing.B) {

--- a/treemap/treemap_test.go
+++ b/treemap/treemap_test.go
@@ -310,16 +310,16 @@ func TestTreeMap_GetSuccessor(t *testing.T) {
 	tm.Put(30, 30)
 	tm.Put(40, 40)
 	tm.Put(50, 50)
-	
+
 	// Root is [20, 40].
 	// Children of 20, 40 are: [10], [30], [50] (if t=2).
 	// Let's make right child of 20 have more keys.
 	tm.Put(35, 35) // Now [30, 35]
-	
+
 	// Left child of 20 is [10] (t-1 = 1). Right child of 20 is [30, 35] (>= t = 2).
 	// If we delete 20, it should borrow from the right child (getSuccessor).
 	tm.Remove(20)
-	
+
 	if tm.ContainsKey(20) {
 		t.Errorf("20 should be removed")
 	}


### PR DESCRIPTION
Applies gofmt -s to the entire codebase to fix the Go Report Card score. Also adds a step to the CI pipeline to enforce gofmt on all future PRs.