### PR TITLE
ci: fix README badge statuses

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,4 +36,10 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -v ./...
+        run: go test -v -coverprofile=coverage.out ./...
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Go Version](https://img.shields.io/github/go-mod/go-version/lock14/collections)](https://go.dev/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/lock14/collections/go.yml?branch=main)](https://github.com/lock14/collections/actions)
-[![Benchmarks](https://img.shields.io/github/actions/workflow/status/lock14/collections/benchmark.yml?branch=main&label=Benchmarks)](https://github.com/lock14/collections/actions/workflows/benchmark.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/lock14/collections)](https://codecov.io/gh/lock14/collections)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lock14/collections)](https://goreportcard.com/report/github.com/lock14/collections)
 [![Go Reference](https://pkg.go.dev/badge/github.com/lock14/collections.svg)](https://pkg.go.dev/github.com/lock14/collections)


### PR DESCRIPTION
This PR fixes the unknown/no status badges on the README by: 1. Removing the benchmark badge since the benchmark workflow only runs on pull requests and thus has no status on main. 2. Adding test coverage generation and uploading it to Codecov inside go.yml, which will resolve the 'unknown' Codecov badge.