### PR TITLE
docs: fix license and restore benchmark badge

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,8 @@
 name: Benchmark Regression Check
 
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -24,7 +26,13 @@ jobs:
       - name: Determine changed packages
         id: changed-pkgs
         run: |
-          GO_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.go')
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE="origin/${{ github.base_ref }}"
+          else
+            BASE="HEAD~1"
+          fi
+          
+          GO_FILES=$(git diff --name-only $BASE...HEAD -- '*.go')
           
           if [ -z "$GO_FILES" ]; then
             echo "No Go files changed. Skipping benchmarks."
@@ -39,6 +47,11 @@ jobs:
 
       - name: Run cob (Performance Regression Check)
         if: steps.changed-pkgs.outputs.skip == 'false'
-        # Compares PR HEAD against the target branch
-        # Fails the pipeline if there is > 20% degradation
-        run: cob -base origin/${{ github.base_ref }} -bench-args "test -run '^$' -bench . -benchmem -benchtime=1s -timeout=30m ${{ steps.changed-pkgs.outputs.pkgs }}"
+        # On PRs, compare against base branch. On pushes to main, compare against previous commit.
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE="origin/${{ github.base_ref }}"
+          else
+            BASE="HEAD~1"
+          fi
+          cob -base $BASE -bench-args "test -run '^$' -bench . -benchmem -benchtime=1s -timeout=30m ${{ steps.changed-pkgs.outputs.pkgs }}"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Version](https://img.shields.io/github/go-mod/go-version/lock14/collections)](https://go.dev/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/lock14/collections/go.yml?branch=main)](https://github.com/lock14/collections/actions)
+[![Benchmarks](https://img.shields.io/github/actions/workflow/status/lock14/collections/benchmark.yml?branch=main&label=Benchmarks)](https://github.com/lock14/collections/actions/workflows/benchmark.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/lock14/collections)](https://codecov.io/gh/lock14/collections)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lock14/collections)](https://goreportcard.com/report/github.com/lock14/collections)
 [![Go Reference](https://pkg.go.dev/badge/github.com/lock14/collections.svg)](https://pkg.go.dev/github.com/lock14/collections)
@@ -74,4 +75,4 @@ Contributions are welcome! We require all tests to pass and benchmarks to show n
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the Apache License, Version 2.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
1. Fixes the license in the README to explicitly state Apache License 2.0. 2. Modifies benchmark.yml to run on push to main (comparing against HEAD~1). This successfully gives the 'Benchmarks' badge a Passing status on the README.