### PR TITLE
build: enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This adds a .gitattributes file enforcing LF line endings and renormalizes the repository. This fixes a persistent bug where Go Report Card treats files as unformatted due to CRLF line endings.