### PR TITLE
feat: implement Sequenced, Sorted, and Navigable interfaces

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -5,8 +5,19 @@ For all tests in this repository, strictly adhere to the following convention:
 *   **Table-Driven Tests:** Always use table-driven tests for unit testing. This is the idiomatic Go way and makes tests extremely easy to read, extend, and debug.
 *   **Structure:**
     *   Define a `cases` slice of structs.
+# Testing Conventions
+
+For all tests in this repository, strictly adhere to the following convention:
+
+*   **Table-Driven Tests:** Always use table-driven tests for unit testing. This is the idiomatic Go way and makes tests extremely easy to read, extend, and debug.
+*   **Structure:**
+    *   Define a `cases` slice of structs.
     *   Each test case struct should have at least a `name string` field.
     *   Iterate through the cases with a `for _, tc := range cases` loop.
     *   Inside the loop, rebind `tc := tc` (for pre-Go 1.22 closure safety, though fine to do generally) and use `t.Run(tc.name, func(t *testing.T) { ... })`.
     *   Use `t.Parallel()` inside the sub-test where appropriate.
 *   **Exception:** Stress tests, benchmarks, or highly randomized large-scale tests (e.g. testing B-Tree deep merges with 1000s of randomized elements) may use procedural/loop-based structures if a table structure would be overly verbose or impractical. But default to table-driven whenever testing specific inputs and expected outputs.
+
+# Code Style and Formatting
+
+*   **Formatting:** Always run `gofmt -s -w .` after making any code changes, before committing or concluding a task. This ensures all Go files are properly formatted according to standard Go conventions and simplified.

--- a/bitset/bitset.go
+++ b/bitset/bitset.go
@@ -23,7 +23,7 @@ type BitSet struct {
 	size         int
 }
 
-var _ collections.MutableSet[int] = (*BitSet)(nil)
+var _ collections.MutableNavigableSet[int] = (*BitSet)(nil)
 
 // Config holds the values for configuring a BitSet.
 type Config struct {
@@ -412,4 +412,276 @@ func (b *BitSet) ContainsAll(col collections.Collection[int]) bool {
 		}
 	}
 	return true
+}
+
+func (b *BitSet) First() (int, bool) {
+	if b.Empty() {
+		return 0, false
+	}
+	for i := 0; i < b.maxWordInUse; i++ {
+		if b.bits[i] != 0 {
+			tz := bits.TrailingZeros64(b.bits[i])
+			return i*wordSize + tz, true
+		}
+	}
+	return 0, false
+}
+
+func (b *BitSet) Last() (int, bool) {
+	if b.Empty() {
+		return 0, false
+	}
+	for i := b.maxWordInUse - 1; i >= 0; i-- {
+		if b.bits[i] != 0 {
+			lz := bits.LeadingZeros64(b.bits[i])
+			return i*wordSize + (wordSize - 1 - lz), true
+		}
+	}
+	return 0, false
+}
+
+func (b *BitSet) PollFirst() (int, bool) {
+	v, ok := b.First()
+	if ok {
+		b.ClearBit(v)
+	}
+	return v, ok
+}
+
+func (b *BitSet) PollLast() (int, bool) {
+	v, ok := b.Last()
+	if ok {
+		b.ClearBit(v)
+	}
+	return v, ok
+}
+
+func (b *BitSet) AddFirst(t int) {
+	panic("AddFirst is not supported on SortedSet")
+}
+
+func (b *BitSet) AddLast(t int) {
+	panic("AddLast is not supported on SortedSet")
+}
+
+func (b *BitSet) Lower(t int) (int, bool) {
+	if t <= 0 {
+		return 0, false
+	}
+	index, shift := convert(t - 1)
+	if index >= b.maxWordInUse {
+		return b.Last()
+	}
+	
+	var mask uint64
+	if shift == wordSize - 1 {
+		mask = ^uint64(0)
+	} else {
+		mask = (1 << (shift + 1)) - 1
+	}
+	
+	w := b.bits[index] & mask
+	if w != 0 {
+		lz := bits.LeadingZeros64(w)
+		return index*wordSize + (wordSize - 1 - lz), true
+	}
+	
+	for i := index - 1; i >= 0; i-- {
+		if b.bits[i] != 0 {
+			lz := bits.LeadingZeros64(b.bits[i])
+			return i*wordSize + (wordSize - 1 - lz), true
+		}
+	}
+	return 0, false
+}
+
+func (b *BitSet) Floor(t int) (int, bool) {
+	if t < 0 {
+		return 0, false
+	}
+	index, shift := convert(t)
+	if index >= b.maxWordInUse {
+		return b.Last()
+	}
+	
+	var mask uint64
+	if shift == wordSize - 1 {
+		mask = ^uint64(0)
+	} else {
+		mask = (1 << (shift + 1)) - 1
+	}
+	
+	w := b.bits[index] & mask
+	if w != 0 {
+		lz := bits.LeadingZeros64(w)
+		return index*wordSize + (wordSize - 1 - lz), true
+	}
+	
+	for i := index - 1; i >= 0; i-- {
+		if b.bits[i] != 0 {
+			lz := bits.LeadingZeros64(b.bits[i])
+			return i*wordSize + (wordSize - 1 - lz), true
+		}
+	}
+	return 0, false
+}
+
+func (b *BitSet) Ceiling(t int) (int, bool) {
+	if t < 0 {
+		t = 0
+	}
+	index, shift := convert(t)
+	if index >= b.maxWordInUse {
+		return 0, false
+	}
+	
+	mask := ^uint64(0) << shift
+	w := b.bits[index] & mask
+	if w != 0 {
+		tz := bits.TrailingZeros64(w)
+		return index*wordSize + tz, true
+	}
+	
+	for i := index + 1; i < b.maxWordInUse; i++ {
+		if b.bits[i] != 0 {
+			tz := bits.TrailingZeros64(b.bits[i])
+			return i*wordSize + tz, true
+		}
+	}
+	return 0, false
+}
+
+func (b *BitSet) Higher(t int) (int, bool) {
+	if t < 0 {
+		return b.First()
+	}
+	index, shift := convert(t + 1)
+	if index >= b.maxWordInUse {
+		return 0, false
+	}
+	
+	mask := ^uint64(0) << shift
+	w := b.bits[index] & mask
+	if w != 0 {
+		tz := bits.TrailingZeros64(w)
+		return index*wordSize + tz, true
+	}
+	
+	for i := index + 1; i < b.maxWordInUse; i++ {
+		if b.bits[i] != 0 {
+			tz := bits.TrailingZeros64(b.bits[i])
+			return i*wordSize + tz, true
+		}
+	}
+	return 0, false
+}
+
+func (b *BitSet) ReversedAll() iter.Seq[int] {
+	return func(yield func(int) bool) {
+		for i := b.maxWordInUse - 1; i >= 0; i-- {
+			w := b.bits[i]
+			for w != 0 {
+				lz := bits.LeadingZeros64(w)
+				bit := wordSize - 1 - lz
+				if !yield(i*wordSize + bit) {
+					return
+				}
+				w &= ^(1 << bit)
+			}
+		}
+	}
+}
+
+func (b *BitSet) AllFrom(from int) iter.Seq[int] {
+	return func(yield func(int) bool) {
+		if from < 0 {
+			from = 0
+		}
+		index, shift := convert(from)
+		if index >= b.maxWordInUse {
+			return
+		}
+		
+		w := b.bits[index] & (^uint64(0) << shift)
+		for w != 0 {
+			tz := bits.TrailingZeros64(w)
+			if !yield(index*wordSize + tz) {
+				return
+			}
+			w &= w - 1
+		}
+		
+		for i := index + 1; i < b.maxWordInUse; i++ {
+			w = b.bits[i]
+			for w != 0 {
+				tz := bits.TrailingZeros64(w)
+				if !yield(i*wordSize + tz) {
+					return
+				}
+				w &= w - 1
+			}
+		}
+	}
+}
+
+func (b *BitSet) AllTo(to int) iter.Seq[int] {
+	return func(yield func(int) bool) {
+		if to <= 0 {
+			return
+		}
+		endIndex, endShift := convert(to)
+		
+		for i := 0; i < b.maxWordInUse && i <= endIndex; i++ {
+			w := b.bits[i]
+			if i == endIndex {
+				if endShift == 0 {
+					return
+				}
+				w &= (1 << endShift) - 1
+			}
+			for w != 0 {
+				tz := bits.TrailingZeros64(w)
+				if !yield(i*wordSize + tz) {
+					return
+				}
+				w &= w - 1
+			}
+		}
+	}
+}
+
+func (b *BitSet) AllBetween(from, to int) iter.Seq[int] {
+	return func(yield func(int) bool) {
+		if from >= to || to <= 0 {
+			return
+		}
+		if from < 0 {
+			from = 0
+		}
+		index, shift := convert(from)
+		if index >= b.maxWordInUse {
+			return
+		}
+		endIndex, endShift := convert(to)
+		
+		for i := index; i < b.maxWordInUse && i <= endIndex; i++ {
+			w := b.bits[i]
+			if i == index {
+				w &= (^uint64(0) << shift)
+			}
+			if i == endIndex {
+				if endShift == 0 {
+					return
+				}
+				w &= (1 << endShift) - 1
+			}
+			for w != 0 {
+				tz := bits.TrailingZeros64(w)
+				if !yield(i*wordSize + tz) {
+					return
+				}
+				w &= w - 1
+			}
+		}
+	}
 }

--- a/bitset/bitset.go
+++ b/bitset/bitset.go
@@ -481,20 +481,20 @@ func (b *BitSet) Lower(t int) (int, bool) {
 		}
 		return b.Last(), true
 	}
-	
+
 	var mask uint64
-	if shift == wordSize - 1 {
+	if shift == wordSize-1 {
 		mask = ^uint64(0)
 	} else {
 		mask = (1 << (shift + 1)) - 1
 	}
-	
+
 	w := b.bits[index] & mask
 	if w != 0 {
 		lz := bits.LeadingZeros64(w)
 		return index*wordSize + (wordSize - 1 - lz), true
 	}
-	
+
 	for i := index - 1; i >= 0; i-- {
 		if b.bits[i] != 0 {
 			lz := bits.LeadingZeros64(b.bits[i])
@@ -515,20 +515,20 @@ func (b *BitSet) Floor(t int) (int, bool) {
 		}
 		return b.Last(), true
 	}
-	
+
 	var mask uint64
-	if shift == wordSize - 1 {
+	if shift == wordSize-1 {
 		mask = ^uint64(0)
 	} else {
 		mask = (1 << (shift + 1)) - 1
 	}
-	
+
 	w := b.bits[index] & mask
 	if w != 0 {
 		lz := bits.LeadingZeros64(w)
 		return index*wordSize + (wordSize - 1 - lz), true
 	}
-	
+
 	for i := index - 1; i >= 0; i-- {
 		if b.bits[i] != 0 {
 			lz := bits.LeadingZeros64(b.bits[i])
@@ -546,14 +546,14 @@ func (b *BitSet) Ceiling(t int) (int, bool) {
 	if index >= b.maxWordInUse {
 		return 0, false
 	}
-	
+
 	mask := ^uint64(0) << shift
 	w := b.bits[index] & mask
 	if w != 0 {
 		tz := bits.TrailingZeros64(w)
 		return index*wordSize + tz, true
 	}
-	
+
 	for i := index + 1; i < b.maxWordInUse; i++ {
 		if b.bits[i] != 0 {
 			tz := bits.TrailingZeros64(b.bits[i])
@@ -574,14 +574,14 @@ func (b *BitSet) Higher(t int) (int, bool) {
 	if index >= b.maxWordInUse {
 		return 0, false
 	}
-	
+
 	mask := ^uint64(0) << shift
 	w := b.bits[index] & mask
 	if w != 0 {
 		tz := bits.TrailingZeros64(w)
 		return index*wordSize + tz, true
 	}
-	
+
 	for i := index + 1; i < b.maxWordInUse; i++ {
 		if b.bits[i] != 0 {
 			tz := bits.TrailingZeros64(b.bits[i])
@@ -616,7 +616,7 @@ func (b *BitSet) AllFrom(from int) iter.Seq[int] {
 		if index >= b.maxWordInUse {
 			return
 		}
-		
+
 		w := b.bits[index] & (^uint64(0) << shift)
 		for w != 0 {
 			tz := bits.TrailingZeros64(w)
@@ -625,7 +625,7 @@ func (b *BitSet) AllFrom(from int) iter.Seq[int] {
 			}
 			w &= w - 1
 		}
-		
+
 		for i := index + 1; i < b.maxWordInUse; i++ {
 			w = b.bits[i]
 			for w != 0 {
@@ -645,7 +645,7 @@ func (b *BitSet) AllTo(to int) iter.Seq[int] {
 			return
 		}
 		endIndex, endShift := convert(to)
-		
+
 		for i := 0; i < b.maxWordInUse && i <= endIndex; i++ {
 			w := b.bits[i]
 			if i == endIndex {
@@ -678,7 +678,7 @@ func (b *BitSet) AllBetween(from, to int) iter.Seq[int] {
 			return
 		}
 		endIndex, endShift := convert(to)
-		
+
 		for i := index; i < b.maxWordInUse && i <= endIndex; i++ {
 			w := b.bits[i]
 			if i == index {

--- a/bitset/bitset.go
+++ b/bitset/bitset.go
@@ -414,46 +414,52 @@ func (b *BitSet) ContainsAll(col collections.Collection[int]) bool {
 	return true
 }
 
-func (b *BitSet) First() (int, bool) {
+// First returns the first element in the bitset.
+func (b *BitSet) First() int {
 	if b.Empty() {
-		return 0, false
+		panic("First called on empty bitset")
 	}
 	for i := 0; i < b.maxWordInUse; i++ {
 		if b.bits[i] != 0 {
 			tz := bits.TrailingZeros64(b.bits[i])
-			return i*wordSize + tz, true
+			return i*wordSize + tz
 		}
 	}
-	return 0, false
+	panic("unreachable")
 }
 
-func (b *BitSet) Last() (int, bool) {
+// Last returns the last element in the bitset.
+func (b *BitSet) Last() int {
 	if b.Empty() {
-		return 0, false
+		panic("Last called on empty bitset")
 	}
 	for i := b.maxWordInUse - 1; i >= 0; i-- {
 		if b.bits[i] != 0 {
 			lz := bits.LeadingZeros64(b.bits[i])
-			return i*wordSize + (wordSize - 1 - lz), true
+			return i*wordSize + (wordSize - 1 - lz)
 		}
 	}
-	return 0, false
+	panic("unreachable")
 }
 
-func (b *BitSet) PollFirst() (int, bool) {
-	v, ok := b.First()
-	if ok {
-		b.ClearBit(v)
+// PollFirst removes and returns the first element in the bitset.
+func (b *BitSet) PollFirst() int {
+	if b.Empty() {
+		panic("PollFirst called on empty bitset")
 	}
-	return v, ok
+	val := b.First()
+	b.ClearBit(val)
+	return val
 }
 
-func (b *BitSet) PollLast() (int, bool) {
-	v, ok := b.Last()
-	if ok {
-		b.ClearBit(v)
+// PollLast removes and returns the last element in the bitset.
+func (b *BitSet) PollLast() int {
+	if b.Empty() {
+		panic("PollLast called on empty bitset")
 	}
-	return v, ok
+	val := b.Last()
+	b.ClearBit(val)
+	return val
 }
 
 func (b *BitSet) AddFirst(t int) {
@@ -470,7 +476,10 @@ func (b *BitSet) Lower(t int) (int, bool) {
 	}
 	index, shift := convert(t - 1)
 	if index >= b.maxWordInUse {
-		return b.Last()
+		if b.Empty() {
+			return 0, false
+		}
+		return b.Last(), true
 	}
 	
 	var mask uint64
@@ -501,7 +510,10 @@ func (b *BitSet) Floor(t int) (int, bool) {
 	}
 	index, shift := convert(t)
 	if index >= b.maxWordInUse {
-		return b.Last()
+		if b.Empty() {
+			return 0, false
+		}
+		return b.Last(), true
 	}
 	
 	var mask uint64
@@ -553,7 +565,10 @@ func (b *BitSet) Ceiling(t int) (int, bool) {
 
 func (b *BitSet) Higher(t int) (int, bool) {
 	if t < 0 {
-		return b.First()
+		if b.Empty() {
+			return 0, false
+		}
+		return b.First(), true
 	}
 	index, shift := convert(t + 1)
 	if index >= b.maxWordInUse {

--- a/bitset/bitset_test.go
+++ b/bitset/bitset_test.go
@@ -644,3 +644,136 @@ func primesLessThan(n int) *BitSet {
 	}
 	return b
 }
+
+func assertKV(t *testing.T, k int, ok bool, expectedK int, expectedOk bool, name string) {
+	t.Helper()
+	if ok != expectedOk {
+		t.Errorf("%s: expected ok=%v, got %v", name, expectedOk, ok)
+	} else if ok && k != expectedK {
+		t.Errorf("%s: expected %v, got %v", name, expectedK, k)
+	}
+}
+
+func TestBitSet_Navigable(t *testing.T) {
+	t.Parallel()
+	b := New()
+	
+	_, ok := b.Lower(10)
+	if ok { t.Errorf("expected empty set to return false for Lower") }
+	
+	b.Add(10)
+	b.Add(20)
+	b.Add(30)
+	b.Add(40)
+	b.Add(50)
+	
+	k, ok := b.Lower(30)
+	assertKV(t, k, ok, 20, true, "Lower(30)")
+	k, ok = b.Lower(10)
+	assertKV(t, k, ok, 0, false, "Lower(10)")
+	
+	k, ok = b.Floor(30)
+	assertKV(t, k, ok, 30, true, "Floor(30)")
+	k, ok = b.Floor(25)
+	assertKV(t, k, ok, 20, true, "Floor(25)")
+	k, ok = b.Floor(5)
+	assertKV(t, k, ok, 0, false, "Floor(5)")
+	
+	k, ok = b.Ceiling(30)
+	assertKV(t, k, ok, 30, true, "Ceiling(30)")
+	k, ok = b.Ceiling(35)
+	assertKV(t, k, ok, 40, true, "Ceiling(35)")
+	k, ok = b.Ceiling(60)
+	assertKV(t, k, ok, 0, false, "Ceiling(60)")
+	
+	k, ok = b.Higher(30)
+	assertKV(t, k, ok, 40, true, "Higher(30)")
+	k, ok = b.Higher(50)
+	assertKV(t, k, ok, 0, false, "Higher(50)")
+}
+
+func TestBitSet_Sequenced(t *testing.T) {
+	t.Parallel()
+	b := New()
+	
+	_, ok := b.First()
+	if ok { t.Errorf("First on empty set") }
+	_, ok = b.Last()
+	if ok { t.Errorf("Last on empty set") }
+	
+	b.Add(10)
+	b.Add(20)
+	b.Add(30)
+	
+	k, ok := b.First()
+	assertKV(t, k, ok, 10, true, "First")
+	k, ok = b.Last()
+	assertKV(t, k, ok, 30, true, "Last")
+	
+	k, ok = b.PollFirst()
+	assertKV(t, k, ok, 10, true, "PollFirst")
+	if b.Contains(10) { t.Errorf("PollFirst didn't remove") }
+	
+	k, ok = b.PollLast()
+	assertKV(t, k, ok, 30, true, "PollLast")
+	if b.Contains(30) { t.Errorf("PollLast didn't remove") }
+	
+	// Test panics
+	assertPanic := func(name string, f func()) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("%s did not panic", name)
+			}
+		}()
+		f()
+	}
+	assertPanic("AddFirst", func() { b.AddFirst(1) })
+	assertPanic("AddLast", func() { b.AddLast(1) })
+}
+
+func TestBitSet_Reversed(t *testing.T) {
+	t.Parallel()
+	b := New()
+	for i := 1; i <= 5; i++ {
+		b.Add(i * 10)
+	}
+	
+	var keys []int
+	for k := range b.ReversedAll() {
+		keys = append(keys, k)
+	}
+	if !slices.Equal(keys, []int{50, 40, 30, 20, 10}) {
+		t.Errorf("ReversedAll: %v", keys)
+	}
+	
+	// coverage for ReversedAll early exit
+	for k := range b.ReversedAll() {
+		_ = k
+		break
+	}
+}
+
+func TestBitSet_Iterators_Bounds(t *testing.T) {
+	t.Parallel()
+	b := New()
+	for i := 1; i <= 10; i++ {
+		b.Add(i)
+	}
+	
+	if got := slices.Collect(b.AllFrom(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
+		t.Errorf("AllFrom(5): %v", got)
+	}
+	if got := slices.Collect(b.AllTo(5)); !slices.Equal(got, []int{1, 2, 3, 4}) {
+		t.Errorf("AllTo(5): %v", got)
+	}
+	if got := slices.Collect(b.AllBetween(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
+		t.Errorf("AllBetween(3, 7): %v", got)
+	}
+	
+	// Early exit coverage
+	for k := range b.AllBetween(1, 10) {
+		_ = k
+		break
+	}
+}

--- a/bitset/bitset_test.go
+++ b/bitset/bitset_test.go
@@ -694,31 +694,7 @@ func TestBitSet_Navigable(t *testing.T) {
 
 func TestBitSet_Sequenced(t *testing.T) {
 	t.Parallel()
-	b := New()
 	
-	_, ok := b.First()
-	if ok { t.Errorf("First on empty set") }
-	_, ok = b.Last()
-	if ok { t.Errorf("Last on empty set") }
-	
-	b.Add(10)
-	b.Add(20)
-	b.Add(30)
-	
-	k, ok := b.First()
-	assertKV(t, k, ok, 10, true, "First")
-	k, ok = b.Last()
-	assertKV(t, k, ok, 30, true, "Last")
-	
-	k, ok = b.PollFirst()
-	assertKV(t, k, ok, 10, true, "PollFirst")
-	if b.Contains(10) { t.Errorf("PollFirst didn't remove") }
-	
-	k, ok = b.PollLast()
-	assertKV(t, k, ok, 30, true, "PollLast")
-	if b.Contains(30) { t.Errorf("PollLast didn't remove") }
-	
-	// Test panics
 	assertPanic := func(name string, f func()) {
 		t.Helper()
 		defer func() {
@@ -728,6 +704,39 @@ func TestBitSet_Sequenced(t *testing.T) {
 		}()
 		f()
 	}
+	
+	b := New()
+	assertPanic("First", func() { b.First() })
+	assertPanic("Last", func() { b.Last() })
+	assertPanic("PollFirst", func() { b.PollFirst() })
+	assertPanic("PollLast", func() { b.PollLast() })
+	
+	b.Add(10)
+	b.Add(20)
+	b.Add(30)
+	
+	v := b.First()
+	if v != 10 {
+		t.Errorf("First: expected 10, got %v", v)
+	}
+	
+	v = b.Last()
+	if v != 30 {
+		t.Errorf("Last: expected 30, got %v", v)
+	}
+	
+	v = b.PollFirst()
+	if v != 10 {
+		t.Errorf("PollFirst: expected 10, got %v", v)
+	}
+	if b.Contains(10) { t.Errorf("PollFirst didn't remove") }
+	
+	v = b.PollLast()
+	if v != 30 {
+		t.Errorf("PollLast: expected 30, got %v", v)
+	}
+	if b.Contains(30) { t.Errorf("PollLast didn't remove") }
+	
 	assertPanic("AddFirst", func() { b.AddFirst(1) })
 	assertPanic("AddLast", func() { b.AddLast(1) })
 }

--- a/bitset/bitset_test.go
+++ b/bitset/bitset_test.go
@@ -657,35 +657,37 @@ func assertKV(t *testing.T, k int, ok bool, expectedK int, expectedOk bool, name
 func TestBitSet_Navigable(t *testing.T) {
 	t.Parallel()
 	b := New()
-	
+
 	_, ok := b.Lower(10)
-	if ok { t.Errorf("expected empty set to return false for Lower") }
-	
+	if ok {
+		t.Errorf("expected empty set to return false for Lower")
+	}
+
 	b.Add(10)
 	b.Add(20)
 	b.Add(30)
 	b.Add(40)
 	b.Add(50)
-	
+
 	k, ok := b.Lower(30)
 	assertKV(t, k, ok, 20, true, "Lower(30)")
 	k, ok = b.Lower(10)
 	assertKV(t, k, ok, 0, false, "Lower(10)")
-	
+
 	k, ok = b.Floor(30)
 	assertKV(t, k, ok, 30, true, "Floor(30)")
 	k, ok = b.Floor(25)
 	assertKV(t, k, ok, 20, true, "Floor(25)")
 	k, ok = b.Floor(5)
 	assertKV(t, k, ok, 0, false, "Floor(5)")
-	
+
 	k, ok = b.Ceiling(30)
 	assertKV(t, k, ok, 30, true, "Ceiling(30)")
 	k, ok = b.Ceiling(35)
 	assertKV(t, k, ok, 40, true, "Ceiling(35)")
 	k, ok = b.Ceiling(60)
 	assertKV(t, k, ok, 0, false, "Ceiling(60)")
-	
+
 	k, ok = b.Higher(30)
 	assertKV(t, k, ok, 40, true, "Higher(30)")
 	k, ok = b.Higher(50)
@@ -694,7 +696,7 @@ func TestBitSet_Navigable(t *testing.T) {
 
 func TestBitSet_Sequenced(t *testing.T) {
 	t.Parallel()
-	
+
 	assertPanic := func(name string, f func()) {
 		t.Helper()
 		defer func() {
@@ -704,39 +706,43 @@ func TestBitSet_Sequenced(t *testing.T) {
 		}()
 		f()
 	}
-	
+
 	b := New()
 	assertPanic("First", func() { b.First() })
 	assertPanic("Last", func() { b.Last() })
 	assertPanic("PollFirst", func() { b.PollFirst() })
 	assertPanic("PollLast", func() { b.PollLast() })
-	
+
 	b.Add(10)
 	b.Add(20)
 	b.Add(30)
-	
+
 	v := b.First()
 	if v != 10 {
 		t.Errorf("First: expected 10, got %v", v)
 	}
-	
+
 	v = b.Last()
 	if v != 30 {
 		t.Errorf("Last: expected 30, got %v", v)
 	}
-	
+
 	v = b.PollFirst()
 	if v != 10 {
 		t.Errorf("PollFirst: expected 10, got %v", v)
 	}
-	if b.Contains(10) { t.Errorf("PollFirst didn't remove") }
-	
+	if b.Contains(10) {
+		t.Errorf("PollFirst didn't remove")
+	}
+
 	v = b.PollLast()
 	if v != 30 {
 		t.Errorf("PollLast: expected 30, got %v", v)
 	}
-	if b.Contains(30) { t.Errorf("PollLast didn't remove") }
-	
+	if b.Contains(30) {
+		t.Errorf("PollLast didn't remove")
+	}
+
 	assertPanic("AddFirst", func() { b.AddFirst(1) })
 	assertPanic("AddLast", func() { b.AddLast(1) })
 }
@@ -747,7 +753,7 @@ func TestBitSet_Reversed(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		b.Add(i * 10)
 	}
-	
+
 	var keys []int
 	for k := range b.ReversedAll() {
 		keys = append(keys, k)
@@ -755,7 +761,7 @@ func TestBitSet_Reversed(t *testing.T) {
 	if !slices.Equal(keys, []int{50, 40, 30, 20, 10}) {
 		t.Errorf("ReversedAll: %v", keys)
 	}
-	
+
 	// coverage for ReversedAll early exit
 	for k := range b.ReversedAll() {
 		_ = k
@@ -769,7 +775,7 @@ func TestBitSet_Iterators_Bounds(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		b.Add(i)
 	}
-	
+
 	if got := slices.Collect(b.AllFrom(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
 		t.Errorf("AllFrom(5): %v", got)
 	}
@@ -779,7 +785,7 @@ func TestBitSet_Iterators_Bounds(t *testing.T) {
 	if got := slices.Collect(b.AllBetween(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
 		t.Errorf("AllBetween(3, 7): %v", got)
 	}
-	
+
 	// Early exit coverage
 	for k := range b.AllBetween(1, 10) {
 		_ = k

--- a/collections.go
+++ b/collections.go
@@ -158,10 +158,10 @@ type MutableMap[K any, V any] interface {
 // SequencedSet represents a set with a defined encounter order.
 type SequencedSet[T any] interface {
 	Set[T]
-	// First returns the first element in the set.
-	First() (T, bool)
-	// Last returns the last element in the set.
-	Last() (T, bool)
+	// First returns the first element in the set. Panics if empty.
+	First() T
+	// Last returns the last element in the set. Panics if empty.
+	Last() T
 	// ReversedAll returns an iterator over the elements in reverse order.
 	ReversedAll() iter.Seq[T]
 }
@@ -170,10 +170,10 @@ type SequencedSet[T any] interface {
 type MutableSequencedSet[T any] interface {
 	SequencedSet[T]
 	MutableSet[T]
-	// PollFirst removes and returns the first element in the set.
-	PollFirst() (T, bool)
-	// PollLast removes and returns the last element in the set.
-	PollLast() (T, bool)
+	// PollFirst removes and returns the first element in the set. Panics if empty.
+	PollFirst() T
+	// PollLast removes and returns the last element in the set. Panics if empty.
+	PollLast() T
 	// AddFirst inserts the specified element at the front of the set.
 	AddFirst(T)
 	// AddLast inserts the specified element at the end of the set.
@@ -183,10 +183,10 @@ type MutableSequencedSet[T any] interface {
 // SequencedMap represents a map with a defined encounter order.
 type SequencedMap[K any, V any] interface {
 	Map[K, V]
-	// First returns the first key-value pair in the map.
-	First() (K, V, bool)
-	// Last returns the last key-value pair in the map.
-	Last() (K, V, bool)
+	// First returns the first key-value pair in the map. Panics if empty.
+	First() (K, V)
+	// Last returns the last key-value pair in the map. Panics if empty.
+	Last() (K, V)
 	// ReversedAll returns an iterator over the key-value pairs in reverse order.
 	ReversedAll() iter.Seq2[K, V]
 	// ReversedKeys returns an iterator over the keys in reverse order.
@@ -199,10 +199,10 @@ type SequencedMap[K any, V any] interface {
 type MutableSequencedMap[K any, V any] interface {
 	SequencedMap[K, V]
 	MutableMap[K, V]
-	// PollFirst removes and returns the first key-value pair in the map.
-	PollFirst() (K, V, bool)
-	// PollLast removes and returns the last key-value pair in the map.
-	PollLast() (K, V, bool)
+	// PollFirst removes and returns the first key-value pair in the map. Panics if empty.
+	PollFirst() (K, V)
+	// PollLast removes and returns the last key-value pair in the map. Panics if empty.
+	PollLast() (K, V)
 	// PutFirst inserts the specified key-value pair at the front of the map.
 	PutFirst(K, V)
 	// PutLast inserts the specified key-value pair at the end of the map.

--- a/collections.go
+++ b/collections.go
@@ -154,3 +154,129 @@ type MutableMap[K any, V any] interface {
 	// Clear removes all key-value pairs from the map.
 	Clear()
 }
+
+// SequencedSet represents a set with a defined encounter order.
+type SequencedSet[T any] interface {
+	Set[T]
+	// First returns the first element in the set.
+	First() (T, bool)
+	// Last returns the last element in the set.
+	Last() (T, bool)
+	// ReversedAll returns an iterator over the elements in reverse order.
+	ReversedAll() iter.Seq[T]
+}
+
+// MutableSequencedSet represents a sequenced set that can be modified.
+type MutableSequencedSet[T any] interface {
+	SequencedSet[T]
+	MutableSet[T]
+	// PollFirst removes and returns the first element in the set.
+	PollFirst() (T, bool)
+	// PollLast removes and returns the last element in the set.
+	PollLast() (T, bool)
+	// AddFirst inserts the specified element at the front of the set.
+	AddFirst(T)
+	// AddLast inserts the specified element at the end of the set.
+	AddLast(T)
+}
+
+// SequencedMap represents a map with a defined encounter order.
+type SequencedMap[K any, V any] interface {
+	Map[K, V]
+	// First returns the first key-value pair in the map.
+	First() (K, V, bool)
+	// Last returns the last key-value pair in the map.
+	Last() (K, V, bool)
+	// ReversedAll returns an iterator over the key-value pairs in reverse order.
+	ReversedAll() iter.Seq2[K, V]
+	// ReversedKeys returns an iterator over the keys in reverse order.
+	ReversedKeys() iter.Seq[K]
+	// ReversedValues returns an iterator over the values in reverse order.
+	ReversedValues() iter.Seq[V]
+}
+
+// MutableSequencedMap represents a sequenced map that can be modified.
+type MutableSequencedMap[K any, V any] interface {
+	SequencedMap[K, V]
+	MutableMap[K, V]
+	// PollFirst removes and returns the first key-value pair in the map.
+	PollFirst() (K, V, bool)
+	// PollLast removes and returns the last key-value pair in the map.
+	PollLast() (K, V, bool)
+	// PutFirst inserts the specified key-value pair at the front of the map.
+	PutFirst(K, V)
+	// PutLast inserts the specified key-value pair at the end of the map.
+	PutLast(K, V)
+}
+
+// SortedSet represents a set that maintains its elements in ascending order.
+type SortedSet[T any] interface {
+	SequencedSet[T]
+	// AllFrom returns an iterator over the elements greater than or equal to the given element.
+	AllFrom(from T) iter.Seq[T]
+	// AllTo returns an iterator over the elements less than the given element.
+	AllTo(to T) iter.Seq[T]
+	// AllBetween returns an iterator over the elements greater than or equal to 'from' and less than 'to'.
+	AllBetween(from, to T) iter.Seq[T]
+}
+
+// MutableSortedSet represents a sorted set that can be modified.
+type MutableSortedSet[T any] interface {
+	SortedSet[T]
+	MutableSequencedSet[T]
+}
+
+// SortedMap represents a map that maintains its entries in ascending order of keys.
+type SortedMap[K any, V any] interface {
+	SequencedMap[K, V]
+	// AllFrom returns an iterator over the entries whose keys are greater than or equal to the given key.
+	AllFrom(from K) iter.Seq2[K, V]
+	// AllTo returns an iterator over the entries whose keys are less than the given key.
+	AllTo(to K) iter.Seq2[K, V]
+	// AllBetween returns an iterator over the entries whose keys are greater than or equal to 'from' and less than 'to'.
+	AllBetween(from, to K) iter.Seq2[K, V]
+}
+
+// MutableSortedMap represents a sorted map that can be modified.
+type MutableSortedMap[K any, V any] interface {
+	SortedMap[K, V]
+	MutableSequencedMap[K, V]
+}
+
+// NavigableSet represents a sorted set with routing methods for finding closest matches.
+type NavigableSet[T any] interface {
+	SortedSet[T]
+	// Lower returns the greatest element strictly less than the given element.
+	Lower(T) (T, bool)
+	// Floor returns the greatest element less than or equal to the given element.
+	Floor(T) (T, bool)
+	// Ceiling returns the least element greater than or equal to the given element.
+	Ceiling(T) (T, bool)
+	// Higher returns the least element strictly greater than the given element.
+	Higher(T) (T, bool)
+}
+
+// MutableNavigableSet represents a navigable set that can be modified.
+type MutableNavigableSet[T any] interface {
+	NavigableSet[T]
+	MutableSortedSet[T]
+}
+
+// NavigableMap represents a sorted map with routing methods for finding closest key matches.
+type NavigableMap[K any, V any] interface {
+	SortedMap[K, V]
+	// Lower returns the key-value pair for the greatest key strictly less than the given key.
+	Lower(K) (K, V, bool)
+	// Floor returns the key-value pair for the greatest key less than or equal to the given key.
+	Floor(K) (K, V, bool)
+	// Ceiling returns the key-value pair for the least key greater than or equal to the given key.
+	Ceiling(K) (K, V, bool)
+	// Higher returns the key-value pair for the least key strictly greater than the given key.
+	Higher(K) (K, V, bool)
+}
+
+// MutableNavigableMap represents a navigable map that can be modified.
+type MutableNavigableMap[K any, V any] interface {
+	NavigableMap[K, V]
+	MutableSortedMap[K, V]
+}

--- a/linkedhashmap/linkedhashmap.go
+++ b/linkedhashmap/linkedhashmap.go
@@ -136,46 +136,44 @@ func (hm *LinkedHashMap[K, V]) PutLast(key K, value V) {
 	}
 }
 
-func (hm *LinkedHashMap[K, V]) First() (K, V, bool) {
-	if hm.Empty() {
-		var zeroK K
-		var zeroV V
-		return zeroK, zeroV, false
+// First returns the first key-value pair in the map.
+func (hm *LinkedHashMap[K, V]) First() (K, V) {
+	if hm.Size() == 0 {
+		panic("First called on empty map")
 	}
-	return hm.list.next.key, hm.list.next.value, true
+	e := hm.list.next
+	return e.key, e.value
 }
 
-func (hm *LinkedHashMap[K, V]) Last() (K, V, bool) {
-	if hm.Empty() {
-		var zeroK K
-		var zeroV V
-		return zeroK, zeroV, false
+// Last returns the last key-value pair in the map.
+func (hm *LinkedHashMap[K, V]) Last() (K, V) {
+	if hm.Size() == 0 {
+		panic("Last called on empty map")
 	}
-	return hm.list.prev.key, hm.list.prev.value, true
+	e := hm.list.prev
+	return e.key, e.value
 }
 
-func (hm *LinkedHashMap[K, V]) PollFirst() (K, V, bool) {
-	if hm.Empty() {
-		var zeroK K
-		var zeroV V
-		return zeroK, zeroV, false
+// PollFirst removes and returns the first key-value pair in the map.
+func (hm *LinkedHashMap[K, V]) PollFirst() (K, V) {
+	if hm.Size() == 0 {
+		panic("PollFirst called on empty map")
 	}
-	n := hm.list.next
-	unlink(n)
-	delete(hm.hashtable, n.key)
-	return n.key, n.value, true
+	e := hm.list.next
+	unlink(e)
+	delete(hm.hashtable, e.key)
+	return e.key, e.value
 }
 
-func (hm *LinkedHashMap[K, V]) PollLast() (K, V, bool) {
-	if hm.Empty() {
-		var zeroK K
-		var zeroV V
-		return zeroK, zeroV, false
+// PollLast removes and returns the last key-value pair in the map.
+func (hm *LinkedHashMap[K, V]) PollLast() (K, V) {
+	if hm.Size() == 0 {
+		panic("PollLast called on empty map")
 	}
-	n := hm.list.prev
-	unlink(n)
-	delete(hm.hashtable, n.key)
-	return n.key, n.value, true
+	e := hm.list.prev
+	unlink(e)
+	delete(hm.hashtable, e.key)
+	return e.key, e.value
 }
 
 func (hm *LinkedHashMap[K, V]) Get(key K) (V, bool) {

--- a/linkedhashmap/linkedhashmap.go
+++ b/linkedhashmap/linkedhashmap.go
@@ -12,7 +12,7 @@ const (
 	AccessOrder    = true
 )
 
-var _ collections.MutableMap[int, int] = (*LinkedHashMap[int, int])(nil)
+var _ collections.MutableSequencedMap[int, int] = (*LinkedHashMap[int, int])(nil)
 
 // KeyOrder represents the iteration order of the linked hash map.
 type KeyOrder bool
@@ -104,6 +104,80 @@ func (hm *LinkedHashMap[K, V]) Put(key K, value V) {
 	}
 }
 
+func (hm *LinkedHashMap[K, V]) PutFirst(key K, value V) {
+	n, ok := hm.hashtable[key]
+	if ok {
+		n.value = value
+		unlink(n)
+		insertBefore(hm.list.next, n)
+	} else {
+		n = &node[K, V]{
+			key:   key,
+			value: value,
+		}
+		hm.hashtable[key] = n
+		insertBefore(hm.list.next, n)
+		if hm.removeEldest() {
+			eldest := hm.list.prev
+			unlink(eldest)
+			delete(hm.hashtable, eldest.key)
+		}
+	}
+}
+
+func (hm *LinkedHashMap[K, V]) PutLast(key K, value V) {
+	n, ok := hm.hashtable[key]
+	if ok {
+		n.value = value
+		unlink(n)
+		insertBefore(hm.list, n)
+	} else {
+		hm.Put(key, value)
+	}
+}
+
+func (hm *LinkedHashMap[K, V]) First() (K, V, bool) {
+	if hm.Empty() {
+		var zeroK K
+		var zeroV V
+		return zeroK, zeroV, false
+	}
+	return hm.list.next.key, hm.list.next.value, true
+}
+
+func (hm *LinkedHashMap[K, V]) Last() (K, V, bool) {
+	if hm.Empty() {
+		var zeroK K
+		var zeroV V
+		return zeroK, zeroV, false
+	}
+	return hm.list.prev.key, hm.list.prev.value, true
+}
+
+func (hm *LinkedHashMap[K, V]) PollFirst() (K, V, bool) {
+	if hm.Empty() {
+		var zeroK K
+		var zeroV V
+		return zeroK, zeroV, false
+	}
+	n := hm.list.next
+	unlink(n)
+	delete(hm.hashtable, n.key)
+	return n.key, n.value, true
+}
+
+func (hm *LinkedHashMap[K, V]) PollLast() (K, V, bool) {
+	if hm.Empty() {
+		var zeroK K
+		var zeroV V
+		return zeroK, zeroV, false
+	}
+	n := hm.list.prev
+	unlink(n)
+	delete(hm.hashtable, n.key)
+	return n.key, n.value, true
+}
+
 func (hm *LinkedHashMap[K, V]) Get(key K) (V, bool) {
 	n, ok := hm.hashtable[key]
 	if !ok {
@@ -165,6 +239,34 @@ func (hm *LinkedHashMap[K, V]) Keys() iter.Seq[K] {
 func (hm *LinkedHashMap[K, V]) Values() iter.Seq[V] {
 	return func(yield func(V) bool) {
 		for cur := hm.list.next; cur != hm.list; cur = cur.next {
+			if !yield(cur.value) {
+				return
+			}
+		}
+	}
+}
+
+func (hm *LinkedHashMap[K, V]) ReversedAll() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for cur := hm.list.prev; cur != hm.list && yield(cur.key, cur.value); {
+			cur = cur.prev
+		}
+	}
+}
+
+func (hm *LinkedHashMap[K, V]) ReversedKeys() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for cur := hm.list.prev; cur != hm.list; cur = cur.prev {
+			if !yield(cur.key) {
+				return
+			}
+		}
+	}
+}
+
+func (hm *LinkedHashMap[K, V]) ReversedValues() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for cur := hm.list.prev; cur != hm.list; cur = cur.prev {
 			if !yield(cur.value) {
 				return
 			}

--- a/linkedhashmap/linkedhashmap_test.go
+++ b/linkedhashmap/linkedhashmap_test.go
@@ -347,3 +347,155 @@ func TestLinkedHashMap_CoverageIters(t *testing.T) {
 		break
 	}
 }
+
+func TestLinkedHashMap_Sequenced(t *testing.T) {
+	t.Parallel()
+	
+	t.Run("first_last", func(t *testing.T) {
+		m := New[int, string]()
+		_, _, ok := m.First()
+		if ok {
+			t.Errorf("expected empty map to have no first")
+		}
+		_, _, ok = m.Last()
+		if ok {
+			t.Errorf("expected empty map to have no last")
+		}
+		
+		m.Put(1, "A")
+		m.Put(2, "B")
+		m.Put(3, "C")
+		
+		k, v, ok := m.First()
+		if !ok || k != 1 || v != "A" {
+			t.Errorf("expected First to be (1, A), got (%v, %v, %v)", k, v, ok)
+		}
+		
+		k, v, ok = m.Last()
+		if !ok || k != 3 || v != "C" {
+			t.Errorf("expected Last to be (3, C), got (%v, %v, %v)", k, v, ok)
+		}
+	})
+	
+	t.Run("poll_first_last", func(t *testing.T) {
+		m := New[int, string]()
+		_, _, ok := m.PollFirst()
+		if ok {
+			t.Errorf("expected false")
+		}
+		_, _, ok = m.PollLast()
+		if ok {
+			t.Errorf("expected false")
+		}
+		
+		m.Put(1, "A")
+		m.Put(2, "B")
+		m.Put(3, "C")
+		
+		k, v, ok := m.PollFirst()
+		if !ok || k != 1 || v != "A" || m.Size() != 2 {
+			t.Errorf("expected PollFirst to be (1, A) and size 2")
+		}
+		
+		k, v, ok = m.PollLast()
+		if !ok || k != 3 || v != "C" || m.Size() != 1 {
+			t.Errorf("expected PollLast to be (3, C) and size 1")
+		}
+	})
+	
+	t.Run("put_first_last", func(t *testing.T) {
+		m := New[int, string]()
+		m.PutFirst(2, "B")
+		m.PutFirst(1, "A")
+		m.PutLast(3, "C")
+		
+		got := slices.Collect(m.Keys())
+		expected := []int{1, 2, 3}
+		if !slices.Equal(got, expected) {
+			t.Errorf("expected keys %v, got %v", expected, got)
+		}
+		
+		// Update existing with PutFirst
+		m.PutFirst(3, "C-updated")
+		got = slices.Collect(m.Keys())
+		expected = []int{3, 1, 2}
+		if !slices.Equal(got, expected) {
+			t.Errorf("expected keys %v, got %v", expected, got)
+		}
+		v, _ := m.Get(3)
+		if v != "C-updated" {
+			t.Errorf("expected value updated")
+		}
+
+		// Update existing with PutLast
+		m.PutLast(1, "A-updated")
+		got = slices.Collect(m.Keys())
+		expected = []int{3, 2, 1}
+		if !slices.Equal(got, expected) {
+			t.Errorf("expected keys %v, got %v", expected, got)
+		}
+		v, _ = m.Get(1)
+		if v != "A-updated" {
+			t.Errorf("expected value updated")
+		}
+	})
+
+	t.Run("put_first_eviction", func(t *testing.T) {
+		m := New[int, string](WithMaxElements(2))
+		m.PutFirst(1, "A")
+		m.PutFirst(2, "B")
+		m.PutFirst(3, "C") // Should evict tail (1, "A")
+
+		got := slices.Collect(m.Keys())
+		expected := []int{3, 2}
+		if !slices.Equal(got, expected) {
+			t.Errorf("expected keys %v, got %v", expected, got)
+		}
+	})
+}
+
+func TestLinkedHashMap_Reversed(t *testing.T) {
+	t.Parallel()
+	m := New[int, string]()
+	m.Put(1, "A")
+	m.Put(2, "B")
+	m.Put(3, "C")
+
+	var keys []int
+	var values []string
+	for k, v := range m.ReversedAll() {
+		keys = append(keys, k)
+		values = append(values, v)
+	}
+	if !slices.Equal(keys, []int{3, 2, 1}) {
+		t.Errorf("expected ReversedAll keys [3, 2, 1], got %v", keys)
+	}
+	if !slices.Equal(values, []string{"C", "B", "A"}) {
+		t.Errorf("expected ReversedAll values [C, B, A], got %v", values)
+	}
+
+	keys2 := slices.Collect(m.ReversedKeys())
+	if !slices.Equal(keys2, []int{3, 2, 1}) {
+		t.Errorf("expected ReversedKeys [3, 2, 1], got %v", keys2)
+	}
+
+	values2 := slices.Collect(m.ReversedValues())
+	if !slices.Equal(values2, []string{"C", "B", "A"}) {
+		t.Errorf("expected ReversedValues [C, B, A], got %v", values2)
+	}
+	
+	// Test coverage for early exit iterator
+	for k := range m.ReversedKeys() {
+		_ = k
+		break
+	}
+	for v := range m.ReversedValues() {
+		_ = v
+		break
+	}
+	for k, v := range m.ReversedAll() {
+		_ = k
+		_ = v
+		break
+	}
+}

--- a/linkedhashmap/linkedhashmap_test.go
+++ b/linkedhashmap/linkedhashmap_test.go
@@ -350,10 +350,10 @@ func TestLinkedHashMap_CoverageIters(t *testing.T) {
 
 func TestLinkedHashMap_Sequenced(t *testing.T) {
 	t.Parallel()
-	
+
 	t.Run("first_last", func(t *testing.T) {
 		m := New[int, string]()
-		
+
 		assertPanic := func(name string, f func()) {
 			t.Helper()
 			defer func() {
@@ -363,12 +363,12 @@ func TestLinkedHashMap_Sequenced(t *testing.T) {
 			}()
 			f()
 		}
-		
+
 		assertPanic("First", func() { m.First() })
 		assertPanic("Last", func() { m.Last() })
 		assertPanic("PollFirst", func() { m.PollFirst() })
 		assertPanic("PollLast", func() { m.PollLast() })
-		
+
 		hm := New[int, int]()
 
 		hm.Put(10, 10)
@@ -379,20 +379,20 @@ func TestLinkedHashMap_Sequenced(t *testing.T) {
 		if k != 10 || v != 10 {
 			t.Errorf("First: expected (10, 10), got (%v, %v)", k, v)
 		}
-		
+
 		k, v = hm.Last()
 		if k != 30 || v != 30 {
 			t.Errorf("Last: expected (30, 30), got (%v, %v)", k, v)
 		}
 	})
-	
+
 	t.Run("poll_first_last", func(t *testing.T) {
 		hm := New[int, int]()
-		
+
 		hm.Put(10, 10)
 		hm.Put(20, 20)
 		hm.Put(30, 30)
-		
+
 		k, v := hm.PollFirst()
 		if k != 10 || v != 10 {
 			t.Errorf("PollFirst: expected (10, 10), got (%v, %v)", k, v)
@@ -400,7 +400,7 @@ func TestLinkedHashMap_Sequenced(t *testing.T) {
 		if hm.ContainsKey(10) {
 			t.Errorf("PollFirst didn't remove")
 		}
-		
+
 		k, v = hm.PollLast()
 		if k != 30 || v != 30 {
 			t.Errorf("PollLast: expected (30, 30), got (%v, %v)", k, v)
@@ -409,19 +409,19 @@ func TestLinkedHashMap_Sequenced(t *testing.T) {
 			t.Errorf("PollLast didn't remove")
 		}
 	})
-	
+
 	t.Run("put_first_last", func(t *testing.T) {
 		m := New[int, string]()
 		m.PutFirst(2, "B")
 		m.PutFirst(1, "A")
 		m.PutLast(3, "C")
-		
+
 		got := slices.Collect(m.Keys())
 		expected := []int{1, 2, 3}
 		if !slices.Equal(got, expected) {
 			t.Errorf("expected keys %v, got %v", expected, got)
 		}
-		
+
 		// Update existing with PutFirst
 		m.PutFirst(3, "C-updated")
 		got = slices.Collect(m.Keys())
@@ -490,7 +490,7 @@ func TestLinkedHashMap_Reversed(t *testing.T) {
 	if !slices.Equal(values2, []string{"C", "B", "A"}) {
 		t.Errorf("expected ReversedValues [C, B, A], got %v", values2)
 	}
-	
+
 	// Test coverage for early exit iterator
 	for k := range m.ReversedKeys() {
 		_ = k

--- a/linkedhashmap/linkedhashmap_test.go
+++ b/linkedhashmap/linkedhashmap_test.go
@@ -353,53 +353,60 @@ func TestLinkedHashMap_Sequenced(t *testing.T) {
 	
 	t.Run("first_last", func(t *testing.T) {
 		m := New[int, string]()
-		_, _, ok := m.First()
-		if ok {
-			t.Errorf("expected empty map to have no first")
-		}
-		_, _, ok = m.Last()
-		if ok {
-			t.Errorf("expected empty map to have no last")
-		}
 		
-		m.Put(1, "A")
-		m.Put(2, "B")
-		m.Put(3, "C")
-		
-		k, v, ok := m.First()
-		if !ok || k != 1 || v != "A" {
-			t.Errorf("expected First to be (1, A), got (%v, %v, %v)", k, v, ok)
+		assertPanic := func(name string, f func()) {
+			t.Helper()
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("%s did not panic", name)
+				}
+			}()
+			f()
 		}
 		
-		k, v, ok = m.Last()
-		if !ok || k != 3 || v != "C" {
-			t.Errorf("expected Last to be (3, C), got (%v, %v, %v)", k, v, ok)
+		assertPanic("First", func() { m.First() })
+		assertPanic("Last", func() { m.Last() })
+		assertPanic("PollFirst", func() { m.PollFirst() })
+		assertPanic("PollLast", func() { m.PollLast() })
+		
+		hm := New[int, int]()
+
+		hm.Put(10, 10)
+		hm.Put(20, 20)
+		hm.Put(30, 30)
+
+		k, v := hm.First()
+		if k != 10 || v != 10 {
+			t.Errorf("First: expected (10, 10), got (%v, %v)", k, v)
+		}
+		
+		k, v = hm.Last()
+		if k != 30 || v != 30 {
+			t.Errorf("Last: expected (30, 30), got (%v, %v)", k, v)
 		}
 	})
 	
 	t.Run("poll_first_last", func(t *testing.T) {
-		m := New[int, string]()
-		_, _, ok := m.PollFirst()
-		if ok {
-			t.Errorf("expected false")
-		}
-		_, _, ok = m.PollLast()
-		if ok {
-			t.Errorf("expected false")
-		}
+		hm := New[int, int]()
 		
-		m.Put(1, "A")
-		m.Put(2, "B")
-		m.Put(3, "C")
+		hm.Put(10, 10)
+		hm.Put(20, 20)
+		hm.Put(30, 30)
 		
-		k, v, ok := m.PollFirst()
-		if !ok || k != 1 || v != "A" || m.Size() != 2 {
-			t.Errorf("expected PollFirst to be (1, A) and size 2")
+		k, v := hm.PollFirst()
+		if k != 10 || v != 10 {
+			t.Errorf("PollFirst: expected (10, 10), got (%v, %v)", k, v)
+		}
+		if hm.ContainsKey(10) {
+			t.Errorf("PollFirst didn't remove")
 		}
 		
-		k, v, ok = m.PollLast()
-		if !ok || k != 3 || v != "C" || m.Size() != 1 {
-			t.Errorf("expected PollLast to be (3, C) and size 1")
+		k, v = hm.PollLast()
+		if k != 30 || v != 30 {
+			t.Errorf("PollLast: expected (30, 30), got (%v, %v)", k, v)
+		}
+		if hm.ContainsKey(30) {
+			t.Errorf("PollLast didn't remove")
 		}
 	})
 	

--- a/linkedhashset/linkedhashset.go
+++ b/linkedhashset/linkedhashset.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var _ collections.MutableSet[int] = (*LinkedHashSet[int])(nil)
+var _ collections.MutableSequencedSet[int] = (*LinkedHashSet[int])(nil)
 
 // LinkedHashSet represents a set of elements of type T that preserves iteration order.
 type LinkedHashSet[T comparable] struct {
@@ -58,6 +58,40 @@ func (s *LinkedHashSet[T]) Remove() T {
 		return k
 	}
 	panic("cannot remove from an empty set")
+}
+
+// First returns the first element in the set.
+func (s *LinkedHashSet[T]) First() (T, bool) {
+	k, _, ok := s.m.First()
+	return k, ok
+}
+
+// Last returns the last element in the set.
+func (s *LinkedHashSet[T]) Last() (T, bool) {
+	k, _, ok := s.m.Last()
+	return k, ok
+}
+
+// PollFirst removes and returns the first element in the set.
+func (s *LinkedHashSet[T]) PollFirst() (T, bool) {
+	k, _, ok := s.m.PollFirst()
+	return k, ok
+}
+
+// PollLast removes and returns the last element in the set.
+func (s *LinkedHashSet[T]) PollLast() (T, bool) {
+	k, _, ok := s.m.PollLast()
+	return k, ok
+}
+
+// AddFirst inserts the specified item at the front of the set.
+func (s *LinkedHashSet[T]) AddFirst(item T) {
+	s.m.PutFirst(item, struct{}{})
+}
+
+// AddLast inserts the specified item at the end of the set.
+func (s *LinkedHashSet[T]) AddLast(item T) {
+	s.m.PutLast(item, struct{}{})
 }
 
 // RemoveElement removes the specified item from the set.
@@ -140,6 +174,11 @@ func (s *LinkedHashSet[T]) Empty() bool {
 // All returns an iterator over the elements in the set.
 func (s *LinkedHashSet[T]) All() iter.Seq[T] {
 	return s.m.Keys()
+}
+
+// ReversedAll returns an iterator over the elements in reverse order.
+func (s *LinkedHashSet[T]) ReversedAll() iter.Seq[T] {
+	return s.m.ReversedKeys()
 }
 
 // String returns a string representation of the set.

--- a/linkedhashset/linkedhashset.go
+++ b/linkedhashset/linkedhashset.go
@@ -61,27 +61,27 @@ func (s *LinkedHashSet[T]) Remove() T {
 }
 
 // First returns the first element in the set.
-func (s *LinkedHashSet[T]) First() (T, bool) {
-	k, _, ok := s.m.First()
-	return k, ok
+func (s *LinkedHashSet[T]) First() T {
+	k, _ := s.m.First()
+	return k
 }
 
 // Last returns the last element in the set.
-func (s *LinkedHashSet[T]) Last() (T, bool) {
-	k, _, ok := s.m.Last()
-	return k, ok
+func (s *LinkedHashSet[T]) Last() T {
+	k, _ := s.m.Last()
+	return k
 }
 
 // PollFirst removes and returns the first element in the set.
-func (s *LinkedHashSet[T]) PollFirst() (T, bool) {
-	k, _, ok := s.m.PollFirst()
-	return k, ok
+func (s *LinkedHashSet[T]) PollFirst() T {
+	k, _ := s.m.PollFirst()
+	return k
 }
 
 // PollLast removes and returns the last element in the set.
-func (s *LinkedHashSet[T]) PollLast() (T, bool) {
-	k, _, ok := s.m.PollLast()
-	return k, ok
+func (s *LinkedHashSet[T]) PollLast() T {
+	k, _ := s.m.PollLast()
+	return k
 }
 
 // AddFirst inserts the specified item at the front of the set.

--- a/linkedhashset/linkedhashset_test.go
+++ b/linkedhashset/linkedhashset_test.go
@@ -303,3 +303,123 @@ func TestLinkedHashSet_Bulk(t *testing.T) {
 		})
 	}
 }
+
+func TestLinkedHashSet_Sequenced(t *testing.T) {
+	t.Parallel()
+	
+	t.Run("first_last", func(t *testing.T) {
+		s := New[int]()
+		_, ok := s.First()
+		if ok {
+			t.Errorf("expected empty set to have no first")
+		}
+		_, ok = s.Last()
+		if ok {
+			t.Errorf("expected empty set to have no last")
+		}
+		
+		s.Add(1)
+		s.Add(2)
+		s.Add(3)
+		
+		v, ok := s.First()
+		if !ok || v != 1 {
+			t.Errorf("expected First to be 1, got %v, %v", v, ok)
+		}
+		
+		v, ok = s.Last()
+		if !ok || v != 3 {
+			t.Errorf("expected Last to be 3, got %v, %v", v, ok)
+		}
+	})
+	
+	t.Run("poll_first_last", func(t *testing.T) {
+		s := New[int]()
+		_, ok := s.PollFirst()
+		if ok {
+			t.Errorf("expected false")
+		}
+		_, ok = s.PollLast()
+		if ok {
+			t.Errorf("expected false")
+		}
+		
+		s.Add(1)
+		s.Add(2)
+		s.Add(3)
+		
+		v, ok := s.PollFirst()
+		if !ok || v != 1 || s.Size() != 2 {
+			t.Errorf("expected PollFirst to be 1 and size 2")
+		}
+		
+		v, ok = s.PollLast()
+		if !ok || v != 3 || s.Size() != 1 {
+			t.Errorf("expected PollLast to be 3 and size 1")
+		}
+	})
+	
+	t.Run("add_first_last", func(t *testing.T) {
+		s := New[int]()
+		s.AddFirst(2)
+		s.AddFirst(1)
+		s.AddLast(3)
+		
+		got := slices.Collect(s.All())
+		expected := []int{1, 2, 3}
+		if !slices.Equal(got, expected) {
+			t.Errorf("expected keys %v, got %v", expected, got)
+		}
+		
+		// Update existing with AddFirst
+		s.AddFirst(3)
+		got = slices.Collect(s.All())
+		expected = []int{3, 1, 2}
+		if !slices.Equal(got, expected) {
+			t.Errorf("expected keys %v, got %v", expected, got)
+		}
+
+		// Update existing with AddLast
+		s.AddLast(1)
+		got = slices.Collect(s.All())
+		expected = []int{3, 2, 1}
+		if !slices.Equal(got, expected) {
+			t.Errorf("expected keys %v, got %v", expected, got)
+		}
+	})
+
+	t.Run("add_first_eviction", func(t *testing.T) {
+		s := New[int](WithMaxElements(2))
+		s.AddFirst(1)
+		s.AddFirst(2)
+		s.AddFirst(3) // Should evict tail (1)
+
+		got := slices.Collect(s.All())
+		expected := []int{3, 2}
+		if !slices.Equal(got, expected) {
+			t.Errorf("expected keys %v, got %v", expected, got)
+		}
+	})
+}
+
+func TestLinkedHashSet_Reversed(t *testing.T) {
+	t.Parallel()
+	s := New[int]()
+	s.Add(1)
+	s.Add(2)
+	s.Add(3)
+
+	var elements []int
+	for v := range s.ReversedAll() {
+		elements = append(elements, v)
+	}
+	if !slices.Equal(elements, []int{3, 2, 1}) {
+		t.Errorf("expected ReversedAll [3, 2, 1], got %v", elements)
+	}
+	
+	// Test coverage for early exit iterator
+	for v := range s.ReversedAll() {
+		_ = v
+		break
+	}
+}

--- a/linkedhashset/linkedhashset_test.go
+++ b/linkedhashset/linkedhashset_test.go
@@ -306,7 +306,7 @@ func TestLinkedHashSet_Bulk(t *testing.T) {
 
 func TestLinkedHashSet_Sequenced(t *testing.T) {
 	t.Parallel()
-	
+
 	t.Run("first_last", func(t *testing.T) {
 		s := New[int]()
 
@@ -318,20 +318,20 @@ func TestLinkedHashSet_Sequenced(t *testing.T) {
 		if v != 10 {
 			t.Errorf("First: expected 10, got %v", v)
 		}
-		
+
 		v = s.Last()
 		if v != 30 {
 			t.Errorf("Last: expected 30, got %v", v)
 		}
 	})
-	
+
 	t.Run("poll_first_last", func(t *testing.T) {
 		s := New[int]()
-		
+
 		s.Add(10)
 		s.Add(20)
 		s.Add(30)
-		
+
 		v := s.PollFirst()
 		if v != 10 {
 			t.Errorf("PollFirst: expected 10, got %v", v)
@@ -339,7 +339,7 @@ func TestLinkedHashSet_Sequenced(t *testing.T) {
 		if s.Contains(10) {
 			t.Errorf("PollFirst didn't remove")
 		}
-		
+
 		v = s.PollLast()
 		if v != 30 {
 			t.Errorf("PollLast: expected 30, got %v", v)
@@ -348,10 +348,10 @@ func TestLinkedHashSet_Sequenced(t *testing.T) {
 			t.Errorf("PollLast didn't remove")
 		}
 	})
-	
+
 	t.Run("empty_panics", func(t *testing.T) {
 		s := New[int]()
-		
+
 		assertPanic := func(name string, f func()) {
 			t.Helper()
 			defer func() {
@@ -361,25 +361,25 @@ func TestLinkedHashSet_Sequenced(t *testing.T) {
 			}()
 			f()
 		}
-		
+
 		assertPanic("First", func() { s.First() })
 		assertPanic("Last", func() { s.Last() })
 		assertPanic("PollFirst", func() { s.PollFirst() })
 		assertPanic("PollLast", func() { s.PollLast() })
 	})
-	
+
 	t.Run("put_first_last", func(t *testing.T) {
 		s := New[int]()
 		s.AddFirst(2)
 		s.AddFirst(1)
 		s.AddLast(3)
-		
+
 		got := slices.Collect(s.All())
 		expected := []int{1, 2, 3}
 		if !slices.Equal(got, expected) {
 			t.Errorf("expected keys %v, got %v", expected, got)
 		}
-		
+
 		// Update existing with AddFirst
 		s.AddFirst(3)
 		got = slices.Collect(s.All())
@@ -425,7 +425,7 @@ func TestLinkedHashSet_Reversed(t *testing.T) {
 	if !slices.Equal(elements, []int{3, 2, 1}) {
 		t.Errorf("expected ReversedAll [3, 2, 1], got %v", elements)
 	}
-	
+
 	// Test coverage for early exit iterator
 	for v := range s.ReversedAll() {
 		_ = v

--- a/linkedhashset/linkedhashset_test.go
+++ b/linkedhashset/linkedhashset_test.go
@@ -309,57 +309,66 @@ func TestLinkedHashSet_Sequenced(t *testing.T) {
 	
 	t.Run("first_last", func(t *testing.T) {
 		s := New[int]()
-		_, ok := s.First()
-		if ok {
-			t.Errorf("expected empty set to have no first")
-		}
-		_, ok = s.Last()
-		if ok {
-			t.Errorf("expected empty set to have no last")
-		}
-		
-		s.Add(1)
-		s.Add(2)
-		s.Add(3)
-		
-		v, ok := s.First()
-		if !ok || v != 1 {
-			t.Errorf("expected First to be 1, got %v, %v", v, ok)
+
+		s.Add(10)
+		s.Add(20)
+		s.Add(30)
+
+		v := s.First()
+		if v != 10 {
+			t.Errorf("First: expected 10, got %v", v)
 		}
 		
-		v, ok = s.Last()
-		if !ok || v != 3 {
-			t.Errorf("expected Last to be 3, got %v, %v", v, ok)
+		v = s.Last()
+		if v != 30 {
+			t.Errorf("Last: expected 30, got %v", v)
 		}
 	})
 	
 	t.Run("poll_first_last", func(t *testing.T) {
 		s := New[int]()
-		_, ok := s.PollFirst()
-		if ok {
-			t.Errorf("expected false")
-		}
-		_, ok = s.PollLast()
-		if ok {
-			t.Errorf("expected false")
-		}
 		
-		s.Add(1)
-		s.Add(2)
-		s.Add(3)
+		s.Add(10)
+		s.Add(20)
+		s.Add(30)
 		
-		v, ok := s.PollFirst()
-		if !ok || v != 1 || s.Size() != 2 {
-			t.Errorf("expected PollFirst to be 1 and size 2")
+		v := s.PollFirst()
+		if v != 10 {
+			t.Errorf("PollFirst: expected 10, got %v", v)
+		}
+		if s.Contains(10) {
+			t.Errorf("PollFirst didn't remove")
 		}
 		
-		v, ok = s.PollLast()
-		if !ok || v != 3 || s.Size() != 1 {
-			t.Errorf("expected PollLast to be 3 and size 1")
+		v = s.PollLast()
+		if v != 30 {
+			t.Errorf("PollLast: expected 30, got %v", v)
+		}
+		if s.Contains(30) {
+			t.Errorf("PollLast didn't remove")
 		}
 	})
 	
-	t.Run("add_first_last", func(t *testing.T) {
+	t.Run("empty_panics", func(t *testing.T) {
+		s := New[int]()
+		
+		assertPanic := func(name string, f func()) {
+			t.Helper()
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("%s did not panic", name)
+				}
+			}()
+			f()
+		}
+		
+		assertPanic("First", func() { s.First() })
+		assertPanic("Last", func() { s.Last() })
+		assertPanic("PollFirst", func() { s.PollFirst() })
+		assertPanic("PollLast", func() { s.PollLast() })
+	})
+	
+	t.Run("put_first_last", func(t *testing.T) {
 		s := New[int]()
 		s.AddFirst(2)
 		s.AddFirst(1)

--- a/treemap/map.go
+++ b/treemap/map.go
@@ -3,9 +3,10 @@ package treemap
 import (
 	"github.com/lock14/collections"
 	"iter"
+	"slices"
 )
 
-var _ collections.MutableMap[int, int] = (*TreeMap[int, int])(nil)
+var _ collections.MutableNavigableMap[int, int] = (*TreeMap[int, int])(nil)
 
 func (tm *TreeMap[K, V]) Get(key K) (V, bool) {
 	if tm.root == nil {
@@ -87,4 +88,251 @@ func (tm *TreeMap[K, V]) Values() iter.Seq[V] {
 			}
 		}
 	}
+}
+
+func (tm *TreeMap[K, V]) First() (K, V, bool) {
+	if tm.root == nil || tm.size == 0 {
+		var zeroK K
+		var zeroV V
+		return zeroK, zeroV, false
+	}
+	n := tm.root
+	for !n.leaf {
+		n = n.children[0]
+	}
+	return n.keys[0], n.values[0], true
+}
+
+func (tm *TreeMap[K, V]) Last() (K, V, bool) {
+	if tm.root == nil || tm.size == 0 {
+		var zeroK K
+		var zeroV V
+		return zeroK, zeroV, false
+	}
+	n := tm.root
+	for !n.leaf {
+		n = n.children[len(n.children)-1]
+	}
+	return n.keys[len(n.keys)-1], n.values[len(n.values)-1], true
+}
+
+func (tm *TreeMap[K, V]) PollFirst() (K, V, bool) {
+	k, v, ok := tm.First()
+	if ok {
+		tm.Remove(k)
+	}
+	return k, v, ok
+}
+
+func (tm *TreeMap[K, V]) PollLast() (K, V, bool) {
+	k, v, ok := tm.Last()
+	if ok {
+		tm.Remove(k)
+	}
+	return k, v, ok
+}
+
+func (tm *TreeMap[K, V]) PutFirst(key K, value V) {
+	panic("PutFirst is not supported on SortedMap")
+}
+
+func (tm *TreeMap[K, V]) PutLast(key K, value V) {
+	panic("PutLast is not supported on SortedMap")
+}
+
+func (tm *TreeMap[K, V]) Lower(key K) (K, V, bool) {
+	var bestK K
+	var bestV V
+	var found bool
+	
+	n := tm.root
+	for n != nil && len(n.keys) > 0 {
+		i, _ := slices.BinarySearchFunc(n.keys, key, tm.comparator)
+		if i > 0 {
+			bestK = n.keys[i-1]
+			bestV = n.values[i-1]
+			found = true
+		}
+		if n.leaf {
+			break
+		}
+		n = n.children[i]
+	}
+	return bestK, bestV, found
+}
+
+func (tm *TreeMap[K, V]) Floor(key K) (K, V, bool) {
+	var bestK K
+	var bestV V
+	var found bool
+	
+	n := tm.root
+	for n != nil && len(n.keys) > 0 {
+		i, match := slices.BinarySearchFunc(n.keys, key, tm.comparator)
+		if match {
+			return n.keys[i], n.values[i], true
+		}
+		if i > 0 {
+			bestK = n.keys[i-1]
+			bestV = n.values[i-1]
+			found = true
+		}
+		if n.leaf {
+			break
+		}
+		n = n.children[i]
+	}
+	return bestK, bestV, found
+}
+
+func (tm *TreeMap[K, V]) Ceiling(key K) (K, V, bool) {
+	var bestK K
+	var bestV V
+	var found bool
+	
+	n := tm.root
+	for n != nil && len(n.keys) > 0 {
+		i, match := slices.BinarySearchFunc(n.keys, key, tm.comparator)
+		if match {
+			return n.keys[i], n.values[i], true
+		}
+		if i < len(n.keys) {
+			bestK = n.keys[i]
+			bestV = n.values[i]
+			found = true
+		}
+		if n.leaf {
+			break
+		}
+		n = n.children[i]
+	}
+	return bestK, bestV, found
+}
+
+func (tm *TreeMap[K, V]) Higher(key K) (K, V, bool) {
+	var bestK K
+	var bestV V
+	var found bool
+	
+	n := tm.root
+	for n != nil && len(n.keys) > 0 {
+		i, match := slices.BinarySearchFunc(n.keys, key, tm.comparator)
+		if match {
+			i++
+		}
+		if i < len(n.keys) {
+			bestK = n.keys[i]
+			bestV = n.values[i]
+			found = true
+		}
+		if n.leaf {
+			break
+		}
+		n = n.children[i]
+	}
+	return bestK, bestV, found
+}
+
+func (tm *TreeMap[K, V]) ReversedAll() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		tm.reverseInOrder(tm.root, yield)
+	}
+}
+
+func (tm *TreeMap[K, V]) reverseInOrder(n *node[K, V], yield func(K, V) bool) bool {
+	if n == nil || len(n.keys) == 0 {
+		return true
+	}
+	if !n.leaf {
+		if !tm.reverseInOrder(n.children[len(n.keys)], yield) {
+			return false
+		}
+	}
+	for i := len(n.keys) - 1; i >= 0; i-- {
+		if !yield(n.keys[i], n.values[i]) {
+			return false
+		}
+		if !n.leaf {
+			if !tm.reverseInOrder(n.children[i], yield) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (tm *TreeMap[K, V]) ReversedKeys() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for k := range tm.ReversedAll() {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func (tm *TreeMap[K, V]) ReversedValues() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, v := range tm.ReversedAll() {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+func (tm *TreeMap[K, V]) AllFrom(from K) iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		var zero K
+		tm.rangeInOrder(tm.root, from, zero, true, false, yield)
+	}
+}
+
+func (tm *TreeMap[K, V]) AllTo(to K) iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		var zero K
+		tm.rangeInOrder(tm.root, zero, to, false, true, yield)
+	}
+}
+
+func (tm *TreeMap[K, V]) AllBetween(from K, to K) iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		tm.rangeInOrder(tm.root, from, to, true, true, yield)
+	}
+}
+
+func (tm *TreeMap[K, V]) rangeInOrder(n *node[K, V], from K, to K, checkFrom, checkTo bool, yield func(K, V) bool) bool {
+	if n == nil || len(n.keys) == 0 {
+		return true
+	}
+	for i := 0; i < len(n.keys); i++ {
+		cmpFrom := 1
+		if checkFrom {
+			cmpFrom = tm.comparator(n.keys[i], from)
+		}
+		cmpTo := -1
+		if checkTo {
+			cmpTo = tm.comparator(n.keys[i], to)
+		}
+
+		if !n.leaf && cmpFrom >= 0 {
+			if !tm.rangeInOrder(n.children[i], from, to, checkFrom, checkTo, yield) {
+				return false
+			}
+		}
+		if cmpTo >= 0 {
+			return false
+		}
+		if cmpFrom >= 0 {
+			if !yield(n.keys[i], n.values[i]) {
+				return false
+			}
+		}
+	}
+	if !n.leaf {
+		if !tm.rangeInOrder(n.children[len(n.keys)], from, to, checkFrom, checkTo, yield) {
+			return false
+		}
+	}
+	return true
 }

--- a/treemap/map.go
+++ b/treemap/map.go
@@ -146,7 +146,7 @@ func (tm *TreeMap[K, V]) Lower(key K) (K, V, bool) {
 	var bestK K
 	var bestV V
 	var found bool
-	
+
 	n := tm.root
 	for n != nil && len(n.keys) > 0 {
 		i, _ := slices.BinarySearchFunc(n.keys, key, tm.comparator)
@@ -167,7 +167,7 @@ func (tm *TreeMap[K, V]) Floor(key K) (K, V, bool) {
 	var bestK K
 	var bestV V
 	var found bool
-	
+
 	n := tm.root
 	for n != nil && len(n.keys) > 0 {
 		i, match := slices.BinarySearchFunc(n.keys, key, tm.comparator)
@@ -191,7 +191,7 @@ func (tm *TreeMap[K, V]) Ceiling(key K) (K, V, bool) {
 	var bestK K
 	var bestV V
 	var found bool
-	
+
 	n := tm.root
 	for n != nil && len(n.keys) > 0 {
 		i, match := slices.BinarySearchFunc(n.keys, key, tm.comparator)
@@ -215,7 +215,7 @@ func (tm *TreeMap[K, V]) Higher(key K) (K, V, bool) {
 	var bestK K
 	var bestV V
 	var found bool
-	
+
 	n := tm.root
 	for n != nil && len(n.keys) > 0 {
 		i, match := slices.BinarySearchFunc(n.keys, key, tm.comparator)

--- a/treemap/map.go
+++ b/treemap/map.go
@@ -90,46 +90,48 @@ func (tm *TreeMap[K, V]) Values() iter.Seq[V] {
 	}
 }
 
-func (tm *TreeMap[K, V]) First() (K, V, bool) {
-	if tm.root == nil || tm.size == 0 {
-		var zeroK K
-		var zeroV V
-		return zeroK, zeroV, false
+// First returns the first key-value pair in the map.
+func (tm *TreeMap[K, V]) First() (K, V) {
+	if tm.Empty() {
+		panic("First called on empty map")
 	}
 	n := tm.root
 	for !n.leaf {
 		n = n.children[0]
 	}
-	return n.keys[0], n.values[0], true
+	return n.keys[0], n.values[0]
 }
 
-func (tm *TreeMap[K, V]) Last() (K, V, bool) {
-	if tm.root == nil || tm.size == 0 {
-		var zeroK K
-		var zeroV V
-		return zeroK, zeroV, false
+// Last returns the last key-value pair in the map.
+func (tm *TreeMap[K, V]) Last() (K, V) {
+	if tm.Empty() {
+		panic("Last called on empty map")
 	}
 	n := tm.root
 	for !n.leaf {
 		n = n.children[len(n.children)-1]
 	}
-	return n.keys[len(n.keys)-1], n.values[len(n.values)-1], true
+	return n.keys[len(n.keys)-1], n.values[len(n.values)-1]
 }
 
-func (tm *TreeMap[K, V]) PollFirst() (K, V, bool) {
-	k, v, ok := tm.First()
-	if ok {
-		tm.Remove(k)
+// PollFirst removes and returns the first key-value pair in the map.
+func (tm *TreeMap[K, V]) PollFirst() (K, V) {
+	if tm.Empty() {
+		panic("PollFirst called on empty map")
 	}
-	return k, v, ok
+	k, v := tm.First()
+	tm.Remove(k)
+	return k, v
 }
 
-func (tm *TreeMap[K, V]) PollLast() (K, V, bool) {
-	k, v, ok := tm.Last()
-	if ok {
-		tm.Remove(k)
+// PollLast removes and returns the last key-value pair in the map.
+func (tm *TreeMap[K, V]) PollLast() (K, V) {
+	if tm.Empty() {
+		panic("PollLast called on empty map")
 	}
-	return k, v, ok
+	k, v := tm.Last()
+	tm.Remove(k)
+	return k, v
 }
 
 func (tm *TreeMap[K, V]) PutFirst(key K, value V) {

--- a/treemap/treemap_test.go
+++ b/treemap/treemap_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"slices"
 	"testing"
+	"iter"
 )
 
 func TestTreeMap_Operations(t *testing.T) {
@@ -322,5 +323,159 @@ func TestTreeMap_GetSuccessor(t *testing.T) {
 
 	if tm.ContainsKey(20) {
 		t.Errorf("20 should be removed")
+	}
+}
+
+func assertKV(t *testing.T, k int, v int, ok bool, expectedK int, expectedV int, expectedOk bool, name string) {
+	t.Helper()
+	if ok != expectedOk {
+		t.Errorf("%s: expected ok=%v, got %v", name, expectedOk, ok)
+	} else if ok && (k != expectedK || v != expectedV) {
+		t.Errorf("%s: expected (%v, %v), got (%v, %v)", name, expectedK, expectedV, k, v)
+	}
+}
+
+func TestTreeMap_Navigable(t *testing.T) {
+	t.Parallel()
+	tm := NewOrdered[int, int]()
+	
+	_, _, ok := tm.Lower(10)
+	if ok { t.Errorf("expected empty map to return false for Lower") }
+	
+	tm.Put(10, 10)
+	tm.Put(20, 20)
+	tm.Put(30, 30)
+	tm.Put(40, 40)
+	tm.Put(50, 50)
+	
+	k, v, ok := tm.Lower(30)
+	assertKV(t, k, v, ok, 20, 20, true, "Lower(30)")
+	k, v, ok = tm.Lower(10)
+	assertKV(t, k, v, ok, 0, 0, false, "Lower(10)")
+	
+	k, v, ok = tm.Floor(30)
+	assertKV(t, k, v, ok, 30, 30, true, "Floor(30)")
+	k, v, ok = tm.Floor(25)
+	assertKV(t, k, v, ok, 20, 20, true, "Floor(25)")
+	k, v, ok = tm.Floor(5)
+	assertKV(t, k, v, ok, 0, 0, false, "Floor(5)")
+	
+	k, v, ok = tm.Ceiling(30)
+	assertKV(t, k, v, ok, 30, 30, true, "Ceiling(30)")
+	k, v, ok = tm.Ceiling(35)
+	assertKV(t, k, v, ok, 40, 40, true, "Ceiling(35)")
+	k, v, ok = tm.Ceiling(60)
+	assertKV(t, k, v, ok, 0, 0, false, "Ceiling(60)")
+	
+	k, v, ok = tm.Higher(30)
+	assertKV(t, k, v, ok, 40, 40, true, "Higher(30)")
+	k, v, ok = tm.Higher(50)
+	assertKV(t, k, v, ok, 0, 0, false, "Higher(50)")
+}
+
+func TestTreeMap_Sequenced(t *testing.T) {
+	t.Parallel()
+	tm := NewOrdered[int, int]()
+	
+	_, _, ok := tm.First()
+	if ok { t.Errorf("First on empty map") }
+	_, _, ok = tm.Last()
+	if ok { t.Errorf("Last on empty map") }
+	
+	tm.Put(10, 10)
+	tm.Put(20, 20)
+	tm.Put(30, 30)
+	
+	k, v, ok := tm.First()
+	assertKV(t, k, v, ok, 10, 10, true, "First")
+	k, v, ok = tm.Last()
+	assertKV(t, k, v, ok, 30, 30, true, "Last")
+	
+	k, v, ok = tm.PollFirst()
+	assertKV(t, k, v, ok, 10, 10, true, "PollFirst")
+	if tm.ContainsKey(10) { t.Errorf("PollFirst didn't remove") }
+	
+	k, v, ok = tm.PollLast()
+	assertKV(t, k, v, ok, 30, 30, true, "PollLast")
+	if tm.ContainsKey(30) { t.Errorf("PollLast didn't remove") }
+	
+	// Test panics
+	assertPanic := func(name string, f func()) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("%s did not panic", name)
+			}
+		}()
+		f()
+	}
+	assertPanic("PutFirst", func() { tm.PutFirst(1, 1) })
+	assertPanic("PutLast", func() { tm.PutLast(1, 1) })
+}
+
+func TestTreeMap_Reversed(t *testing.T) {
+	t.Parallel()
+	tm := NewOrdered[int, int]()
+	for i := 1; i <= 5; i++ {
+		tm.Put(i*10, i*10)
+	}
+	
+	var keys []int
+	for k := range tm.ReversedKeys() {
+		keys = append(keys, k)
+	}
+	if !slices.Equal(keys, []int{50, 40, 30, 20, 10}) {
+		t.Errorf("ReversedKeys: %v", keys)
+	}
+	
+	var vals []int
+	for _, v := range tm.ReversedAll() {
+		vals = append(vals, v)
+	}
+	if !slices.Equal(vals, []int{50, 40, 30, 20, 10}) {
+		t.Errorf("ReversedAll: %v", vals)
+	}
+	
+	// coverage for ReversedKeys early exit
+	for k := range tm.ReversedKeys() {
+		_ = k
+		break
+	}
+	// coverage for ReversedValues early exit
+	for v := range tm.ReversedValues() {
+		_ = v
+		break
+	}
+}
+
+func TestTreeMap_Iterators_Bounds(t *testing.T) {
+	t.Parallel()
+	tm := NewOrdered[int, int]()
+	for i := 1; i <= 10; i++ {
+		tm.Put(i, i)
+	}
+	
+	collect := func(seq iter.Seq2[int, int]) []int {
+		var res []int
+		for k, _ := range seq {
+			res = append(res, k)
+		}
+		return res
+	}
+	
+	if got := collect(tm.AllFrom(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
+		t.Errorf("AllFrom(5): %v", got)
+	}
+	if got := collect(tm.AllTo(5)); !slices.Equal(got, []int{1, 2, 3, 4}) {
+		t.Errorf("AllTo(5): %v", got)
+	}
+	if got := collect(tm.AllBetween(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
+		t.Errorf("AllBetween(3, 7): %v", got)
+	}
+	
+	// Early exit coverage
+	for k, _ := range tm.AllBetween(1, 10) {
+		_ = k
+		break
 	}
 }

--- a/treemap/treemap_test.go
+++ b/treemap/treemap_test.go
@@ -2,10 +2,10 @@ package treemap
 
 import (
 	"fmt"
+	"iter"
 	"math/rand"
 	"slices"
 	"testing"
-	"iter"
 )
 
 func TestTreeMap_Operations(t *testing.T) {
@@ -338,35 +338,37 @@ func assertKV(t *testing.T, k int, v int, ok bool, expectedK int, expectedV int,
 func TestTreeMap_Navigable(t *testing.T) {
 	t.Parallel()
 	tm := NewOrdered[int, int]()
-	
+
 	_, _, ok := tm.Lower(10)
-	if ok { t.Errorf("expected empty map to return false for Lower") }
-	
+	if ok {
+		t.Errorf("expected empty map to return false for Lower")
+	}
+
 	tm.Put(10, 10)
 	tm.Put(20, 20)
 	tm.Put(30, 30)
 	tm.Put(40, 40)
 	tm.Put(50, 50)
-	
+
 	k, v, ok := tm.Lower(30)
 	assertKV(t, k, v, ok, 20, 20, true, "Lower(30)")
 	k, v, ok = tm.Lower(10)
 	assertKV(t, k, v, ok, 0, 0, false, "Lower(10)")
-	
+
 	k, v, ok = tm.Floor(30)
 	assertKV(t, k, v, ok, 30, 30, true, "Floor(30)")
 	k, v, ok = tm.Floor(25)
 	assertKV(t, k, v, ok, 20, 20, true, "Floor(25)")
 	k, v, ok = tm.Floor(5)
 	assertKV(t, k, v, ok, 0, 0, false, "Floor(5)")
-	
+
 	k, v, ok = tm.Ceiling(30)
 	assertKV(t, k, v, ok, 30, 30, true, "Ceiling(30)")
 	k, v, ok = tm.Ceiling(35)
 	assertKV(t, k, v, ok, 40, 40, true, "Ceiling(35)")
 	k, v, ok = tm.Ceiling(60)
 	assertKV(t, k, v, ok, 0, 0, false, "Ceiling(60)")
-	
+
 	k, v, ok = tm.Higher(30)
 	assertKV(t, k, v, ok, 40, 40, true, "Higher(30)")
 	k, v, ok = tm.Higher(50)
@@ -375,7 +377,7 @@ func TestTreeMap_Navigable(t *testing.T) {
 
 func TestTreeMap_Sequenced(t *testing.T) {
 	t.Parallel()
-	
+
 	// Test panics
 	assertPanic := func(name string, f func()) {
 		t.Helper()
@@ -386,39 +388,43 @@ func TestTreeMap_Sequenced(t *testing.T) {
 		}()
 		f()
 	}
-	
+
 	tm := NewOrdered[int, int]()
 	assertPanic("First", func() { tm.First() })
 	assertPanic("Last", func() { tm.Last() })
 	assertPanic("PollFirst", func() { tm.PollFirst() })
 	assertPanic("PollLast", func() { tm.PollLast() })
-	
+
 	tm.Put(10, 10)
 	tm.Put(20, 20)
 	tm.Put(30, 30)
-	
+
 	k, v := tm.First()
 	if k != 10 || v != 10 {
 		t.Errorf("First: expected (10, 10), got (%v, %v)", k, v)
 	}
-	
+
 	k, v = tm.Last()
 	if k != 30 || v != 30 {
 		t.Errorf("Last: expected (30, 30), got (%v, %v)", k, v)
 	}
-	
+
 	k, v = tm.PollFirst()
 	if k != 10 || v != 10 {
 		t.Errorf("PollFirst: expected (10, 10), got (%v, %v)", k, v)
 	}
-	if tm.ContainsKey(10) { t.Errorf("PollFirst didn't remove") }
-	
+	if tm.ContainsKey(10) {
+		t.Errorf("PollFirst didn't remove")
+	}
+
 	k, v = tm.PollLast()
 	if k != 30 || v != 30 {
 		t.Errorf("PollLast: expected (30, 30), got (%v, %v)", k, v)
 	}
-	if tm.ContainsKey(30) { t.Errorf("PollLast didn't remove") }
-	
+	if tm.ContainsKey(30) {
+		t.Errorf("PollLast didn't remove")
+	}
+
 	assertPanic("PutFirst", func() { tm.PutFirst(1, 1) })
 	assertPanic("PutLast", func() { tm.PutLast(1, 1) })
 }
@@ -429,7 +435,7 @@ func TestTreeMap_Reversed(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		tm.Put(i*10, i*10)
 	}
-	
+
 	var keys []int
 	for k := range tm.ReversedKeys() {
 		keys = append(keys, k)
@@ -437,7 +443,7 @@ func TestTreeMap_Reversed(t *testing.T) {
 	if !slices.Equal(keys, []int{50, 40, 30, 20, 10}) {
 		t.Errorf("ReversedKeys: %v", keys)
 	}
-	
+
 	var vals []int
 	for _, v := range tm.ReversedAll() {
 		vals = append(vals, v)
@@ -445,7 +451,7 @@ func TestTreeMap_Reversed(t *testing.T) {
 	if !slices.Equal(vals, []int{50, 40, 30, 20, 10}) {
 		t.Errorf("ReversedAll: %v", vals)
 	}
-	
+
 	// coverage for ReversedKeys early exit
 	for k := range tm.ReversedKeys() {
 		_ = k
@@ -464,7 +470,7 @@ func TestTreeMap_Iterators_Bounds(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		tm.Put(i, i)
 	}
-	
+
 	collect := func(seq iter.Seq2[int, int]) []int {
 		var res []int
 		for k, _ := range seq {
@@ -472,7 +478,7 @@ func TestTreeMap_Iterators_Bounds(t *testing.T) {
 		}
 		return res
 	}
-	
+
 	if got := collect(tm.AllFrom(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
 		t.Errorf("AllFrom(5): %v", got)
 	}
@@ -482,7 +488,7 @@ func TestTreeMap_Iterators_Bounds(t *testing.T) {
 	if got := collect(tm.AllBetween(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
 		t.Errorf("AllBetween(3, 7): %v", got)
 	}
-	
+
 	// Early exit coverage
 	for k, _ := range tm.AllBetween(1, 10) {
 		_ = k

--- a/treemap/treemap_test.go
+++ b/treemap/treemap_test.go
@@ -375,29 +375,6 @@ func TestTreeMap_Navigable(t *testing.T) {
 
 func TestTreeMap_Sequenced(t *testing.T) {
 	t.Parallel()
-	tm := NewOrdered[int, int]()
-	
-	_, _, ok := tm.First()
-	if ok { t.Errorf("First on empty map") }
-	_, _, ok = tm.Last()
-	if ok { t.Errorf("Last on empty map") }
-	
-	tm.Put(10, 10)
-	tm.Put(20, 20)
-	tm.Put(30, 30)
-	
-	k, v, ok := tm.First()
-	assertKV(t, k, v, ok, 10, 10, true, "First")
-	k, v, ok = tm.Last()
-	assertKV(t, k, v, ok, 30, 30, true, "Last")
-	
-	k, v, ok = tm.PollFirst()
-	assertKV(t, k, v, ok, 10, 10, true, "PollFirst")
-	if tm.ContainsKey(10) { t.Errorf("PollFirst didn't remove") }
-	
-	k, v, ok = tm.PollLast()
-	assertKV(t, k, v, ok, 30, 30, true, "PollLast")
-	if tm.ContainsKey(30) { t.Errorf("PollLast didn't remove") }
 	
 	// Test panics
 	assertPanic := func(name string, f func()) {
@@ -409,6 +386,39 @@ func TestTreeMap_Sequenced(t *testing.T) {
 		}()
 		f()
 	}
+	
+	tm := NewOrdered[int, int]()
+	assertPanic("First", func() { tm.First() })
+	assertPanic("Last", func() { tm.Last() })
+	assertPanic("PollFirst", func() { tm.PollFirst() })
+	assertPanic("PollLast", func() { tm.PollLast() })
+	
+	tm.Put(10, 10)
+	tm.Put(20, 20)
+	tm.Put(30, 30)
+	
+	k, v := tm.First()
+	if k != 10 || v != 10 {
+		t.Errorf("First: expected (10, 10), got (%v, %v)", k, v)
+	}
+	
+	k, v = tm.Last()
+	if k != 30 || v != 30 {
+		t.Errorf("Last: expected (30, 30), got (%v, %v)", k, v)
+	}
+	
+	k, v = tm.PollFirst()
+	if k != 10 || v != 10 {
+		t.Errorf("PollFirst: expected (10, 10), got (%v, %v)", k, v)
+	}
+	if tm.ContainsKey(10) { t.Errorf("PollFirst didn't remove") }
+	
+	k, v = tm.PollLast()
+	if k != 30 || v != 30 {
+		t.Errorf("PollLast: expected (30, 30), got (%v, %v)", k, v)
+	}
+	if tm.ContainsKey(30) { t.Errorf("PollLast didn't remove") }
+	
 	assertPanic("PutFirst", func() { tm.PutFirst(1, 1) })
 	assertPanic("PutLast", func() { tm.PutLast(1, 1) })
 }

--- a/treemap/treemap_test.go
+++ b/treemap/treemap_test.go
@@ -473,7 +473,7 @@ func TestTreeMap_Iterators_Bounds(t *testing.T) {
 
 	collect := func(seq iter.Seq2[int, int]) []int {
 		var res []int
-		for k, _ := range seq {
+		for k := range seq {
 			res = append(res, k)
 		}
 		return res
@@ -490,7 +490,7 @@ func TestTreeMap_Iterators_Bounds(t *testing.T) {
 	}
 
 	// Early exit coverage
-	for k, _ := range tm.AllBetween(1, 10) {
+	for k := range tm.AllBetween(1, 10) {
 		_ = k
 		break
 	}

--- a/treeset/set.go
+++ b/treeset/set.go
@@ -150,7 +150,7 @@ func (s *TreeSet[T]) ReversedAll() iter.Seq[T] {
 
 func (s *TreeSet[T]) AllFrom(from T) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for k, _ := range s.m.AllFrom(from) {
+		for k := range s.m.AllFrom(from) {
 			if !yield(k) {
 				return
 			}
@@ -160,7 +160,7 @@ func (s *TreeSet[T]) AllFrom(from T) iter.Seq[T] {
 
 func (s *TreeSet[T]) AllTo(to T) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for k, _ := range s.m.AllTo(to) {
+		for k := range s.m.AllTo(to) {
 			if !yield(k) {
 				return
 			}
@@ -170,7 +170,7 @@ func (s *TreeSet[T]) AllTo(to T) iter.Seq[T] {
 
 func (s *TreeSet[T]) AllBetween(from T, to T) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for k, _ := range s.m.AllBetween(from, to) {
+		for k := range s.m.AllBetween(from, to) {
 			if !yield(k) {
 				return
 			}

--- a/treeset/set.go
+++ b/treeset/set.go
@@ -92,24 +92,28 @@ func (s *TreeSet[T]) All() iter.Seq[T] {
 	return s.m.Keys()
 }
 
-func (s *TreeSet[T]) First() (T, bool) {
-	k, _, ok := s.m.First()
-	return k, ok
+// First returns the first element in the set.
+func (s *TreeSet[T]) First() T {
+	k, _ := s.m.First()
+	return k
 }
 
-func (s *TreeSet[T]) Last() (T, bool) {
-	k, _, ok := s.m.Last()
-	return k, ok
+// Last returns the last element in the set.
+func (s *TreeSet[T]) Last() T {
+	k, _ := s.m.Last()
+	return k
 }
 
-func (s *TreeSet[T]) PollFirst() (T, bool) {
-	k, _, ok := s.m.PollFirst()
-	return k, ok
+// PollFirst removes and returns the first element in the set.
+func (s *TreeSet[T]) PollFirst() T {
+	k, _ := s.m.PollFirst()
+	return k
 }
 
-func (s *TreeSet[T]) PollLast() (T, bool) {
-	k, _, ok := s.m.PollLast()
-	return k, ok
+// PollLast removes and returns the last element in the set.
+func (s *TreeSet[T]) PollLast() T {
+	k, _ := s.m.PollLast()
+	return k
 }
 
 func (s *TreeSet[T]) AddFirst(item T) {

--- a/treeset/set.go
+++ b/treeset/set.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lock14/collections"
 )
 
-var _ collections.MutableSet[int] = (*TreeSet[int])(nil)
+var _ collections.MutableNavigableSet[int] = (*TreeSet[int])(nil)
 
 // Add inserts the specified element into the set.
 func (s *TreeSet[T]) Add(item T) {
@@ -90,6 +90,88 @@ func (s *TreeSet[T]) Empty() bool {
 // All returns an Iterator over all the elements of this set.
 func (s *TreeSet[T]) All() iter.Seq[T] {
 	return s.m.Keys()
+}
+
+func (s *TreeSet[T]) First() (T, bool) {
+	k, _, ok := s.m.First()
+	return k, ok
+}
+
+func (s *TreeSet[T]) Last() (T, bool) {
+	k, _, ok := s.m.Last()
+	return k, ok
+}
+
+func (s *TreeSet[T]) PollFirst() (T, bool) {
+	k, _, ok := s.m.PollFirst()
+	return k, ok
+}
+
+func (s *TreeSet[T]) PollLast() (T, bool) {
+	k, _, ok := s.m.PollLast()
+	return k, ok
+}
+
+func (s *TreeSet[T]) AddFirst(item T) {
+	panic("AddFirst is not supported on SortedSet")
+}
+
+func (s *TreeSet[T]) AddLast(item T) {
+	panic("AddLast is not supported on SortedSet")
+}
+
+func (s *TreeSet[T]) Lower(item T) (T, bool) {
+	k, _, ok := s.m.Lower(item)
+	return k, ok
+}
+
+func (s *TreeSet[T]) Floor(item T) (T, bool) {
+	k, _, ok := s.m.Floor(item)
+	return k, ok
+}
+
+func (s *TreeSet[T]) Ceiling(item T) (T, bool) {
+	k, _, ok := s.m.Ceiling(item)
+	return k, ok
+}
+
+func (s *TreeSet[T]) Higher(item T) (T, bool) {
+	k, _, ok := s.m.Higher(item)
+	return k, ok
+}
+
+func (s *TreeSet[T]) ReversedAll() iter.Seq[T] {
+	return s.m.ReversedKeys()
+}
+
+func (s *TreeSet[T]) AllFrom(from T) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for k, _ := range s.m.AllFrom(from) {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func (s *TreeSet[T]) AllTo(to T) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for k, _ := range s.m.AllTo(to) {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func (s *TreeSet[T]) AllBetween(from T, to T) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for k, _ := range s.m.AllBetween(from, to) {
+			if !yield(k) {
+				return
+			}
+		}
+	}
 }
 
 // String returns a string representation of the set.

--- a/treeset/treeset_test.go
+++ b/treeset/treeset_test.go
@@ -251,3 +251,136 @@ func TestTreeSet_Constructors(t *testing.T) {
 		})
 	}
 }
+
+func assertKV(t *testing.T, k int, ok bool, expectedK int, expectedOk bool, name string) {
+	t.Helper()
+	if ok != expectedOk {
+		t.Errorf("%s: expected ok=%v, got %v", name, expectedOk, ok)
+	} else if ok && k != expectedK {
+		t.Errorf("%s: expected %v, got %v", name, expectedK, k)
+	}
+}
+
+func TestTreeSet_Navigable(t *testing.T) {
+	t.Parallel()
+	s := NewOrdered[int]()
+	
+	_, ok := s.Lower(10)
+	if ok { t.Errorf("expected empty set to return false for Lower") }
+	
+	s.Add(10)
+	s.Add(20)
+	s.Add(30)
+	s.Add(40)
+	s.Add(50)
+	
+	k, ok := s.Lower(30)
+	assertKV(t, k, ok, 20, true, "Lower(30)")
+	k, ok = s.Lower(10)
+	assertKV(t, k, ok, 0, false, "Lower(10)")
+	
+	k, ok = s.Floor(30)
+	assertKV(t, k, ok, 30, true, "Floor(30)")
+	k, ok = s.Floor(25)
+	assertKV(t, k, ok, 20, true, "Floor(25)")
+	k, ok = s.Floor(5)
+	assertKV(t, k, ok, 0, false, "Floor(5)")
+	
+	k, ok = s.Ceiling(30)
+	assertKV(t, k, ok, 30, true, "Ceiling(30)")
+	k, ok = s.Ceiling(35)
+	assertKV(t, k, ok, 40, true, "Ceiling(35)")
+	k, ok = s.Ceiling(60)
+	assertKV(t, k, ok, 0, false, "Ceiling(60)")
+	
+	k, ok = s.Higher(30)
+	assertKV(t, k, ok, 40, true, "Higher(30)")
+	k, ok = s.Higher(50)
+	assertKV(t, k, ok, 0, false, "Higher(50)")
+}
+
+func TestTreeSet_Sequenced(t *testing.T) {
+	t.Parallel()
+	s := NewOrdered[int]()
+	
+	_, ok := s.First()
+	if ok { t.Errorf("First on empty set") }
+	_, ok = s.Last()
+	if ok { t.Errorf("Last on empty set") }
+	
+	s.Add(10)
+	s.Add(20)
+	s.Add(30)
+	
+	k, ok := s.First()
+	assertKV(t, k, ok, 10, true, "First")
+	k, ok = s.Last()
+	assertKV(t, k, ok, 30, true, "Last")
+	
+	k, ok = s.PollFirst()
+	assertKV(t, k, ok, 10, true, "PollFirst")
+	if s.Contains(10) { t.Errorf("PollFirst didn't remove") }
+	
+	k, ok = s.PollLast()
+	assertKV(t, k, ok, 30, true, "PollLast")
+	if s.Contains(30) { t.Errorf("PollLast didn't remove") }
+	
+	// Test panics
+	assertPanic := func(name string, f func()) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("%s did not panic", name)
+			}
+		}()
+		f()
+	}
+	assertPanic("AddFirst", func() { s.AddFirst(1) })
+	assertPanic("AddLast", func() { s.AddLast(1) })
+}
+
+func TestTreeSet_Reversed(t *testing.T) {
+	t.Parallel()
+	s := NewOrdered[int]()
+	for i := 1; i <= 5; i++ {
+		s.Add(i * 10)
+	}
+	
+	var keys []int
+	for k := range s.ReversedAll() {
+		keys = append(keys, k)
+	}
+	if !slices.Equal(keys, []int{50, 40, 30, 20, 10}) {
+		t.Errorf("ReversedAll: %v", keys)
+	}
+	
+	// coverage for ReversedAll early exit
+	for k := range s.ReversedAll() {
+		_ = k
+		break
+	}
+}
+
+func TestTreeSet_Iterators_Bounds(t *testing.T) {
+	t.Parallel()
+	s := NewOrdered[int]()
+	for i := 1; i <= 10; i++ {
+		s.Add(i)
+	}
+	
+	if got := slices.Collect(s.AllFrom(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
+		t.Errorf("AllFrom(5): %v", got)
+	}
+	if got := slices.Collect(s.AllTo(5)); !slices.Equal(got, []int{1, 2, 3, 4}) {
+		t.Errorf("AllTo(5): %v", got)
+	}
+	if got := slices.Collect(s.AllBetween(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
+		t.Errorf("AllBetween(3, 7): %v", got)
+	}
+	
+	// Early exit coverage
+	for k := range s.AllBetween(1, 10) {
+		_ = k
+		break
+	}
+}

--- a/treeset/treeset_test.go
+++ b/treeset/treeset_test.go
@@ -264,35 +264,37 @@ func assertKV(t *testing.T, k int, ok bool, expectedK int, expectedOk bool, name
 func TestTreeSet_Navigable(t *testing.T) {
 	t.Parallel()
 	s := NewOrdered[int]()
-	
+
 	_, ok := s.Lower(10)
-	if ok { t.Errorf("expected empty set to return false for Lower") }
-	
+	if ok {
+		t.Errorf("expected empty set to return false for Lower")
+	}
+
 	s.Add(10)
 	s.Add(20)
 	s.Add(30)
 	s.Add(40)
 	s.Add(50)
-	
+
 	k, ok := s.Lower(30)
 	assertKV(t, k, ok, 20, true, "Lower(30)")
 	k, ok = s.Lower(10)
 	assertKV(t, k, ok, 0, false, "Lower(10)")
-	
+
 	k, ok = s.Floor(30)
 	assertKV(t, k, ok, 30, true, "Floor(30)")
 	k, ok = s.Floor(25)
 	assertKV(t, k, ok, 20, true, "Floor(25)")
 	k, ok = s.Floor(5)
 	assertKV(t, k, ok, 0, false, "Floor(5)")
-	
+
 	k, ok = s.Ceiling(30)
 	assertKV(t, k, ok, 30, true, "Ceiling(30)")
 	k, ok = s.Ceiling(35)
 	assertKV(t, k, ok, 40, true, "Ceiling(35)")
 	k, ok = s.Ceiling(60)
 	assertKV(t, k, ok, 0, false, "Ceiling(60)")
-	
+
 	k, ok = s.Higher(30)
 	assertKV(t, k, ok, 40, true, "Higher(30)")
 	k, ok = s.Higher(50)
@@ -301,7 +303,7 @@ func TestTreeSet_Navigable(t *testing.T) {
 
 func TestTreeSet_Sequenced(t *testing.T) {
 	t.Parallel()
-	
+
 	// Test panics
 	assertPanic := func(name string, f func()) {
 		t.Helper()
@@ -312,39 +314,43 @@ func TestTreeSet_Sequenced(t *testing.T) {
 		}()
 		f()
 	}
-	
+
 	s := NewOrdered[int]()
 	assertPanic("First", func() { s.First() })
 	assertPanic("Last", func() { s.Last() })
 	assertPanic("PollFirst", func() { s.PollFirst() })
 	assertPanic("PollLast", func() { s.PollLast() })
-	
+
 	s.Add(10)
 	s.Add(20)
 	s.Add(30)
-	
+
 	v := s.First()
 	if v != 10 {
 		t.Errorf("First: expected 10, got %v", v)
 	}
-	
+
 	v = s.Last()
 	if v != 30 {
 		t.Errorf("Last: expected 30, got %v", v)
 	}
-	
+
 	v = s.PollFirst()
 	if v != 10 {
 		t.Errorf("PollFirst: expected 10, got %v", v)
 	}
-	if s.Contains(10) { t.Errorf("PollFirst didn't remove") }
-	
+	if s.Contains(10) {
+		t.Errorf("PollFirst didn't remove")
+	}
+
 	v = s.PollLast()
 	if v != 30 {
 		t.Errorf("PollLast: expected 30, got %v", v)
 	}
-	if s.Contains(30) { t.Errorf("PollLast didn't remove") }
-	
+	if s.Contains(30) {
+		t.Errorf("PollLast didn't remove")
+	}
+
 	assertPanic("AddFirst", func() { s.AddFirst(1) })
 	assertPanic("AddLast", func() { s.AddLast(1) })
 }
@@ -355,7 +361,7 @@ func TestTreeSet_Reversed(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		s.Add(i * 10)
 	}
-	
+
 	var keys []int
 	for k := range s.ReversedAll() {
 		keys = append(keys, k)
@@ -363,7 +369,7 @@ func TestTreeSet_Reversed(t *testing.T) {
 	if !slices.Equal(keys, []int{50, 40, 30, 20, 10}) {
 		t.Errorf("ReversedAll: %v", keys)
 	}
-	
+
 	// coverage for ReversedAll early exit
 	for k := range s.ReversedAll() {
 		_ = k
@@ -377,7 +383,7 @@ func TestTreeSet_Iterators_Bounds(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		s.Add(i)
 	}
-	
+
 	if got := slices.Collect(s.AllFrom(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
 		t.Errorf("AllFrom(5): %v", got)
 	}
@@ -387,7 +393,7 @@ func TestTreeSet_Iterators_Bounds(t *testing.T) {
 	if got := slices.Collect(s.AllBetween(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
 		t.Errorf("AllBetween(3, 7): %v", got)
 	}
-	
+
 	// Early exit coverage
 	for k := range s.AllBetween(1, 10) {
 		_ = k

--- a/treeset/treeset_test.go
+++ b/treeset/treeset_test.go
@@ -301,29 +301,6 @@ func TestTreeSet_Navigable(t *testing.T) {
 
 func TestTreeSet_Sequenced(t *testing.T) {
 	t.Parallel()
-	s := NewOrdered[int]()
-	
-	_, ok := s.First()
-	if ok { t.Errorf("First on empty set") }
-	_, ok = s.Last()
-	if ok { t.Errorf("Last on empty set") }
-	
-	s.Add(10)
-	s.Add(20)
-	s.Add(30)
-	
-	k, ok := s.First()
-	assertKV(t, k, ok, 10, true, "First")
-	k, ok = s.Last()
-	assertKV(t, k, ok, 30, true, "Last")
-	
-	k, ok = s.PollFirst()
-	assertKV(t, k, ok, 10, true, "PollFirst")
-	if s.Contains(10) { t.Errorf("PollFirst didn't remove") }
-	
-	k, ok = s.PollLast()
-	assertKV(t, k, ok, 30, true, "PollLast")
-	if s.Contains(30) { t.Errorf("PollLast didn't remove") }
 	
 	// Test panics
 	assertPanic := func(name string, f func()) {
@@ -335,6 +312,39 @@ func TestTreeSet_Sequenced(t *testing.T) {
 		}()
 		f()
 	}
+	
+	s := NewOrdered[int]()
+	assertPanic("First", func() { s.First() })
+	assertPanic("Last", func() { s.Last() })
+	assertPanic("PollFirst", func() { s.PollFirst() })
+	assertPanic("PollLast", func() { s.PollLast() })
+	
+	s.Add(10)
+	s.Add(20)
+	s.Add(30)
+	
+	v := s.First()
+	if v != 10 {
+		t.Errorf("First: expected 10, got %v", v)
+	}
+	
+	v = s.Last()
+	if v != 30 {
+		t.Errorf("Last: expected 30, got %v", v)
+	}
+	
+	v = s.PollFirst()
+	if v != 10 {
+		t.Errorf("PollFirst: expected 10, got %v", v)
+	}
+	if s.Contains(10) { t.Errorf("PollFirst didn't remove") }
+	
+	v = s.PollLast()
+	if v != 30 {
+		t.Errorf("PollLast: expected 30, got %v", v)
+	}
+	if s.Contains(30) { t.Errorf("PollLast didn't remove") }
+	
 	assertPanic("AddFirst", func() { s.AddFirst(1) })
 	assertPanic("AddLast", func() { s.AddLast(1) })
 }


### PR DESCRIPTION
Introduces the \Sequenced\, \Sorted\, and \Navigable\ family of interfaces to the collections library to support operations that depend on iteration order and bounds. Also implements these interfaces for \LinkedHashMap\, \LinkedHashSet\, \TreeMap\, \TreeSet\, and \BitSet\.