### PR TITLE
refactor: rename iterators to match go 1.23 conventions

### DIFF
--- a/bitset/bitset.go
+++ b/bitset/bitset.go
@@ -591,7 +591,7 @@ func (b *BitSet) Higher(t int) (int, bool) {
 	return 0, false
 }
 
-func (b *BitSet) ReversedAll() iter.Seq[int] {
+func (b *BitSet) Backward() iter.Seq[int] {
 	return func(yield func(int) bool) {
 		for i := b.maxWordInUse - 1; i >= 0; i-- {
 			w := b.bits[i]
@@ -607,7 +607,7 @@ func (b *BitSet) ReversedAll() iter.Seq[int] {
 	}
 }
 
-func (b *BitSet) AllFrom(from int) iter.Seq[int] {
+func (b *BitSet) From(from int) iter.Seq[int] {
 	return func(yield func(int) bool) {
 		if from < 0 {
 			from = 0
@@ -639,7 +639,7 @@ func (b *BitSet) AllFrom(from int) iter.Seq[int] {
 	}
 }
 
-func (b *BitSet) AllTo(to int) iter.Seq[int] {
+func (b *BitSet) To(to int) iter.Seq[int] {
 	return func(yield func(int) bool) {
 		if to <= 0 {
 			return
@@ -665,7 +665,7 @@ func (b *BitSet) AllTo(to int) iter.Seq[int] {
 	}
 }
 
-func (b *BitSet) AllBetween(from, to int) iter.Seq[int] {
+func (b *BitSet) Between(from, to int) iter.Seq[int] {
 	return func(yield func(int) bool) {
 		if from >= to || to <= 0 {
 			return

--- a/bitset/bitset_test.go
+++ b/bitset/bitset_test.go
@@ -747,7 +747,7 @@ func TestBitSet_Sequenced(t *testing.T) {
 	assertPanic("AddLast", func() { b.AddLast(1) })
 }
 
-func TestBitSet_Reversed(t *testing.T) {
+func TestBitSet_Backward(t *testing.T) {
 	t.Parallel()
 	b := New()
 	for i := 1; i <= 5; i++ {
@@ -755,15 +755,15 @@ func TestBitSet_Reversed(t *testing.T) {
 	}
 
 	var keys []int
-	for k := range b.ReversedAll() {
+	for k := range b.Backward() {
 		keys = append(keys, k)
 	}
 	if !slices.Equal(keys, []int{50, 40, 30, 20, 10}) {
-		t.Errorf("ReversedAll: %v", keys)
+		t.Errorf("Backward: %v", keys)
 	}
 
-	// coverage for ReversedAll early exit
-	for k := range b.ReversedAll() {
+	// coverage for Backward early exit
+	for k := range b.Backward() {
 		_ = k
 		break
 	}
@@ -776,18 +776,18 @@ func TestBitSet_Iterators_Bounds(t *testing.T) {
 		b.Add(i)
 	}
 
-	if got := slices.Collect(b.AllFrom(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
-		t.Errorf("AllFrom(5): %v", got)
+	if got := slices.Collect(b.From(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
+		t.Errorf("From(5): %v", got)
 	}
-	if got := slices.Collect(b.AllTo(5)); !slices.Equal(got, []int{1, 2, 3, 4}) {
-		t.Errorf("AllTo(5): %v", got)
+	if got := slices.Collect(b.To(5)); !slices.Equal(got, []int{1, 2, 3, 4}) {
+		t.Errorf("To(5): %v", got)
 	}
-	if got := slices.Collect(b.AllBetween(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
-		t.Errorf("AllBetween(3, 7): %v", got)
+	if got := slices.Collect(b.Between(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
+		t.Errorf("Between(3, 7): %v", got)
 	}
 
 	// Early exit coverage
-	for k := range b.AllBetween(1, 10) {
+	for k := range b.Between(1, 10) {
 		_ = k
 		break
 	}

--- a/collections.go
+++ b/collections.go
@@ -162,8 +162,8 @@ type SequencedSet[T any] interface {
 	First() T
 	// Last returns the last element in the set. Panics if empty.
 	Last() T
-	// ReversedAll returns an iterator over the elements in reverse order.
-	ReversedAll() iter.Seq[T]
+	// Backward returns an iterator over the elements in reverse order.
+	Backward() iter.Seq[T]
 }
 
 // MutableSequencedSet represents a sequenced set that can be modified.
@@ -187,12 +187,12 @@ type SequencedMap[K any, V any] interface {
 	First() (K, V)
 	// Last returns the last key-value pair in the map. Panics if empty.
 	Last() (K, V)
-	// ReversedAll returns an iterator over the key-value pairs in reverse order.
-	ReversedAll() iter.Seq2[K, V]
-	// ReversedKeys returns an iterator over the keys in reverse order.
-	ReversedKeys() iter.Seq[K]
-	// ReversedValues returns an iterator over the values in reverse order.
-	ReversedValues() iter.Seq[V]
+	// Backward returns an iterator over the key-value pairs in reverse order.
+	Backward() iter.Seq2[K, V]
+	// BackwardKeys returns an iterator over the keys in reverse order.
+	BackwardKeys() iter.Seq[K]
+	// BackwardValues returns an iterator over the values in reverse order.
+	BackwardValues() iter.Seq[V]
 }
 
 // MutableSequencedMap represents a sequenced map that can be modified.
@@ -212,12 +212,12 @@ type MutableSequencedMap[K any, V any] interface {
 // SortedSet represents a set that maintains its elements in ascending order.
 type SortedSet[T any] interface {
 	SequencedSet[T]
-	// AllFrom returns an iterator over the elements greater than or equal to the given element.
-	AllFrom(from T) iter.Seq[T]
-	// AllTo returns an iterator over the elements less than the given element.
-	AllTo(to T) iter.Seq[T]
-	// AllBetween returns an iterator over the elements greater than or equal to 'from' and less than 'to'.
-	AllBetween(from, to T) iter.Seq[T]
+	// From returns an iterator over the elements greater than or equal to the given element.
+	From(from T) iter.Seq[T]
+	// To returns an iterator over the elements less than the given element.
+	To(to T) iter.Seq[T]
+	// Between returns an iterator over the elements greater than or equal to 'from' and less than 'to'.
+	Between(from, to T) iter.Seq[T]
 }
 
 // MutableSortedSet represents a sorted set that can be modified.
@@ -229,12 +229,12 @@ type MutableSortedSet[T any] interface {
 // SortedMap represents a map that maintains its entries in ascending order of keys.
 type SortedMap[K any, V any] interface {
 	SequencedMap[K, V]
-	// AllFrom returns an iterator over the entries whose keys are greater than or equal to the given key.
-	AllFrom(from K) iter.Seq2[K, V]
-	// AllTo returns an iterator over the entries whose keys are less than the given key.
-	AllTo(to K) iter.Seq2[K, V]
-	// AllBetween returns an iterator over the entries whose keys are greater than or equal to 'from' and less than 'to'.
-	AllBetween(from, to K) iter.Seq2[K, V]
+	// From returns an iterator over the entries whose keys are greater than or equal to the given key.
+	From(from K) iter.Seq2[K, V]
+	// To returns an iterator over the entries whose keys are less than the given key.
+	To(to K) iter.Seq2[K, V]
+	// Between returns an iterator over the entries whose keys are greater than or equal to 'from' and less than 'to'.
+	Between(from, to K) iter.Seq2[K, V]
 }
 
 // MutableSortedMap represents a sorted map that can be modified.

--- a/linkedhashmap/linkedhashmap.go
+++ b/linkedhashmap/linkedhashmap.go
@@ -244,7 +244,7 @@ func (hm *LinkedHashMap[K, V]) Values() iter.Seq[V] {
 	}
 }
 
-func (hm *LinkedHashMap[K, V]) ReversedAll() iter.Seq2[K, V] {
+func (hm *LinkedHashMap[K, V]) Backward() iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		for cur := hm.list.prev; cur != hm.list && yield(cur.key, cur.value); {
 			cur = cur.prev
@@ -252,7 +252,7 @@ func (hm *LinkedHashMap[K, V]) ReversedAll() iter.Seq2[K, V] {
 	}
 }
 
-func (hm *LinkedHashMap[K, V]) ReversedKeys() iter.Seq[K] {
+func (hm *LinkedHashMap[K, V]) BackwardKeys() iter.Seq[K] {
 	return func(yield func(K) bool) {
 		for cur := hm.list.prev; cur != hm.list; cur = cur.prev {
 			if !yield(cur.key) {
@@ -262,7 +262,7 @@ func (hm *LinkedHashMap[K, V]) ReversedKeys() iter.Seq[K] {
 	}
 }
 
-func (hm *LinkedHashMap[K, V]) ReversedValues() iter.Seq[V] {
+func (hm *LinkedHashMap[K, V]) BackwardValues() iter.Seq[V] {
 	return func(yield func(V) bool) {
 		for cur := hm.list.prev; cur != hm.list; cur = cur.prev {
 			if !yield(cur.value) {

--- a/linkedhashmap/linkedhashmap_test.go
+++ b/linkedhashmap/linkedhashmap_test.go
@@ -461,7 +461,7 @@ func TestLinkedHashMap_Sequenced(t *testing.T) {
 	})
 }
 
-func TestLinkedHashMap_Reversed(t *testing.T) {
+func TestLinkedHashMap_Backward(t *testing.T) {
 	t.Parallel()
 	m := New[int, string]()
 	m.Put(1, "A")
@@ -470,39 +470,38 @@ func TestLinkedHashMap_Reversed(t *testing.T) {
 
 	var keys []int
 	var values []string
-	for k, v := range m.ReversedAll() {
+	for k, v := range m.Backward() {
 		keys = append(keys, k)
 		values = append(values, v)
 	}
 	if !slices.Equal(keys, []int{3, 2, 1}) {
-		t.Errorf("expected ReversedAll keys [3, 2, 1], got %v", keys)
+		t.Errorf("expected Backward keys [3, 2, 1], got %v", keys)
 	}
 	if !slices.Equal(values, []string{"C", "B", "A"}) {
-		t.Errorf("expected ReversedAll values [C, B, A], got %v", values)
+		t.Errorf("expected Backward values [C, B, A], got %v", values)
 	}
 
-	keys2 := slices.Collect(m.ReversedKeys())
+	keys2 := slices.Collect(m.BackwardKeys())
 	if !slices.Equal(keys2, []int{3, 2, 1}) {
-		t.Errorf("expected ReversedKeys [3, 2, 1], got %v", keys2)
+		t.Errorf("expected BackwardKeys [3, 2, 1], got %v", keys2)
 	}
 
-	values2 := slices.Collect(m.ReversedValues())
+	values2 := slices.Collect(m.BackwardValues())
 	if !slices.Equal(values2, []string{"C", "B", "A"}) {
-		t.Errorf("expected ReversedValues [C, B, A], got %v", values2)
+		t.Errorf("expected BackwardValues [C, B, A], got %v", values2)
 	}
 
-	// Test coverage for early exit iterator
-	for k := range m.ReversedKeys() {
+	// cover early exits
+	for k := range m.BackwardKeys() {
 		_ = k
 		break
 	}
-	for v := range m.ReversedValues() {
+	for v := range m.BackwardValues() {
 		_ = v
 		break
 	}
-	for k, v := range m.ReversedAll() {
-		_ = k
-		_ = v
+	for k, v := range m.Backward() {
+		_, _ = k, v
 		break
 	}
 }

--- a/linkedhashset/linkedhashset.go
+++ b/linkedhashset/linkedhashset.go
@@ -176,9 +176,9 @@ func (s *LinkedHashSet[T]) All() iter.Seq[T] {
 	return s.m.Keys()
 }
 
-// ReversedAll returns an iterator over the elements in reverse order.
-func (s *LinkedHashSet[T]) ReversedAll() iter.Seq[T] {
-	return s.m.ReversedKeys()
+// Backward returns an iterator over the elements in reverse order.
+func (s *LinkedHashSet[T]) Backward() iter.Seq[T] {
+	return s.m.BackwardKeys()
 }
 
 // String returns a string representation of the set.

--- a/linkedhashset/linkedhashset_test.go
+++ b/linkedhashset/linkedhashset_test.go
@@ -411,7 +411,7 @@ func TestLinkedHashSet_Sequenced(t *testing.T) {
 	})
 }
 
-func TestLinkedHashSet_Reversed(t *testing.T) {
+func TestLinkedHashSet_Backward(t *testing.T) {
 	t.Parallel()
 	s := New[int]()
 	s.Add(1)
@@ -419,15 +419,15 @@ func TestLinkedHashSet_Reversed(t *testing.T) {
 	s.Add(3)
 
 	var elements []int
-	for v := range s.ReversedAll() {
+	for v := range s.Backward() {
 		elements = append(elements, v)
 	}
 	if !slices.Equal(elements, []int{3, 2, 1}) {
-		t.Errorf("expected ReversedAll [3, 2, 1], got %v", elements)
+		t.Errorf("expected Backward [3, 2, 1], got %v", elements)
 	}
 
 	// Test coverage for early exit iterator
-	for v := range s.ReversedAll() {
+	for v := range s.Backward() {
 		_ = v
 		break
 	}

--- a/treemap/map.go
+++ b/treemap/map.go
@@ -235,7 +235,7 @@ func (tm *TreeMap[K, V]) Higher(key K) (K, V, bool) {
 	return bestK, bestV, found
 }
 
-func (tm *TreeMap[K, V]) ReversedAll() iter.Seq2[K, V] {
+func (tm *TreeMap[K, V]) Backward() iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		tm.reverseInOrder(tm.root, yield)
 	}
@@ -263,9 +263,9 @@ func (tm *TreeMap[K, V]) reverseInOrder(n *node[K, V], yield func(K, V) bool) bo
 	return true
 }
 
-func (tm *TreeMap[K, V]) ReversedKeys() iter.Seq[K] {
+func (tm *TreeMap[K, V]) BackwardKeys() iter.Seq[K] {
 	return func(yield func(K) bool) {
-		for k := range tm.ReversedAll() {
+		for k := range tm.Backward() {
 			if !yield(k) {
 				return
 			}
@@ -273,9 +273,9 @@ func (tm *TreeMap[K, V]) ReversedKeys() iter.Seq[K] {
 	}
 }
 
-func (tm *TreeMap[K, V]) ReversedValues() iter.Seq[V] {
+func (tm *TreeMap[K, V]) BackwardValues() iter.Seq[V] {
 	return func(yield func(V) bool) {
-		for _, v := range tm.ReversedAll() {
+		for _, v := range tm.Backward() {
 			if !yield(v) {
 				return
 			}
@@ -283,21 +283,21 @@ func (tm *TreeMap[K, V]) ReversedValues() iter.Seq[V] {
 	}
 }
 
-func (tm *TreeMap[K, V]) AllFrom(from K) iter.Seq2[K, V] {
+func (tm *TreeMap[K, V]) From(from K) iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		var zero K
 		tm.rangeInOrder(tm.root, from, zero, true, false, yield)
 	}
 }
 
-func (tm *TreeMap[K, V]) AllTo(to K) iter.Seq2[K, V] {
+func (tm *TreeMap[K, V]) To(to K) iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		var zero K
 		tm.rangeInOrder(tm.root, zero, to, false, true, yield)
 	}
 }
 
-func (tm *TreeMap[K, V]) AllBetween(from K, to K) iter.Seq2[K, V] {
+func (tm *TreeMap[K, V]) Between(from K, to K) iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		tm.rangeInOrder(tm.root, from, to, true, true, yield)
 	}

--- a/treemap/treemap_test.go
+++ b/treemap/treemap_test.go
@@ -429,7 +429,7 @@ func TestTreeMap_Sequenced(t *testing.T) {
 	assertPanic("PutLast", func() { tm.PutLast(1, 1) })
 }
 
-func TestTreeMap_Reversed(t *testing.T) {
+func TestTreeMap_Backward(t *testing.T) {
 	t.Parallel()
 	tm := NewOrdered[int, int]()
 	for i := 1; i <= 5; i++ {
@@ -437,28 +437,28 @@ func TestTreeMap_Reversed(t *testing.T) {
 	}
 
 	var keys []int
-	for k := range tm.ReversedKeys() {
+	for k := range tm.BackwardKeys() {
 		keys = append(keys, k)
 	}
 	if !slices.Equal(keys, []int{50, 40, 30, 20, 10}) {
-		t.Errorf("ReversedKeys: %v", keys)
+		t.Errorf("BackwardKeys: %v", keys)
 	}
 
 	var vals []int
-	for _, v := range tm.ReversedAll() {
+	for _, v := range tm.Backward() {
 		vals = append(vals, v)
 	}
 	if !slices.Equal(vals, []int{50, 40, 30, 20, 10}) {
-		t.Errorf("ReversedAll: %v", vals)
+		t.Errorf("Backward: %v", vals)
 	}
 
-	// coverage for ReversedKeys early exit
-	for k := range tm.ReversedKeys() {
+	// coverage for BackwardKeys early exit
+	for k := range tm.BackwardKeys() {
 		_ = k
 		break
 	}
-	// coverage for ReversedValues early exit
-	for v := range tm.ReversedValues() {
+	// coverage for BackwardValues early exit
+	for v := range tm.BackwardValues() {
 		_ = v
 		break
 	}
@@ -479,18 +479,18 @@ func TestTreeMap_Iterators_Bounds(t *testing.T) {
 		return res
 	}
 
-	if got := collect(tm.AllFrom(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
-		t.Errorf("AllFrom(5): %v", got)
+	if got := collect(tm.From(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
+		t.Errorf("From(5): %v", got)
 	}
-	if got := collect(tm.AllTo(5)); !slices.Equal(got, []int{1, 2, 3, 4}) {
-		t.Errorf("AllTo(5): %v", got)
+	if got := collect(tm.To(5)); !slices.Equal(got, []int{1, 2, 3, 4}) {
+		t.Errorf("To(5): %v", got)
 	}
-	if got := collect(tm.AllBetween(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
-		t.Errorf("AllBetween(3, 7): %v", got)
+	if got := collect(tm.Between(4, 8)); !slices.Equal(got, []int{4, 5, 6, 7}) {
+		t.Errorf("Between(4, 8): %v", got)
 	}
 
 	// Early exit coverage
-	for k := range tm.AllBetween(1, 10) {
+	for k := range tm.Between(1, 10) {
 		_ = k
 		break
 	}

--- a/treeset/set.go
+++ b/treeset/set.go
@@ -144,13 +144,13 @@ func (s *TreeSet[T]) Higher(item T) (T, bool) {
 	return k, ok
 }
 
-func (s *TreeSet[T]) ReversedAll() iter.Seq[T] {
-	return s.m.ReversedKeys()
+func (s *TreeSet[T]) Backward() iter.Seq[T] {
+	return s.m.BackwardKeys()
 }
 
-func (s *TreeSet[T]) AllFrom(from T) iter.Seq[T] {
+func (s *TreeSet[T]) From(from T) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for k := range s.m.AllFrom(from) {
+		for k := range s.m.From(from) {
 			if !yield(k) {
 				return
 			}
@@ -158,9 +158,9 @@ func (s *TreeSet[T]) AllFrom(from T) iter.Seq[T] {
 	}
 }
 
-func (s *TreeSet[T]) AllTo(to T) iter.Seq[T] {
+func (s *TreeSet[T]) To(to T) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for k := range s.m.AllTo(to) {
+		for k := range s.m.To(to) {
 			if !yield(k) {
 				return
 			}
@@ -168,9 +168,9 @@ func (s *TreeSet[T]) AllTo(to T) iter.Seq[T] {
 	}
 }
 
-func (s *TreeSet[T]) AllBetween(from T, to T) iter.Seq[T] {
+func (s *TreeSet[T]) Between(from, to T) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for k := range s.m.AllBetween(from, to) {
+		for k := range s.m.Between(from, to) {
 			if !yield(k) {
 				return
 			}

--- a/treeset/treeset_test.go
+++ b/treeset/treeset_test.go
@@ -355,7 +355,7 @@ func TestTreeSet_Sequenced(t *testing.T) {
 	assertPanic("AddLast", func() { s.AddLast(1) })
 }
 
-func TestTreeSet_Reversed(t *testing.T) {
+func TestTreeSet_Backward(t *testing.T) {
 	t.Parallel()
 	s := NewOrdered[int]()
 	for i := 1; i <= 5; i++ {
@@ -363,15 +363,15 @@ func TestTreeSet_Reversed(t *testing.T) {
 	}
 
 	var keys []int
-	for k := range s.ReversedAll() {
+	for k := range s.Backward() {
 		keys = append(keys, k)
 	}
 	if !slices.Equal(keys, []int{50, 40, 30, 20, 10}) {
-		t.Errorf("ReversedAll: %v", keys)
+		t.Errorf("Backward: %v", keys)
 	}
 
-	// coverage for ReversedAll early exit
-	for k := range s.ReversedAll() {
+	// coverage for Backward early exit
+	for k := range s.Backward() {
 		_ = k
 		break
 	}
@@ -384,18 +384,18 @@ func TestTreeSet_Iterators_Bounds(t *testing.T) {
 		s.Add(i)
 	}
 
-	if got := slices.Collect(s.AllFrom(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
-		t.Errorf("AllFrom(5): %v", got)
+	if got := slices.Collect(s.From(5)); !slices.Equal(got, []int{5, 6, 7, 8, 9, 10}) {
+		t.Errorf("From(5): %v", got)
 	}
-	if got := slices.Collect(s.AllTo(5)); !slices.Equal(got, []int{1, 2, 3, 4}) {
-		t.Errorf("AllTo(5): %v", got)
+	if got := slices.Collect(s.To(5)); !slices.Equal(got, []int{1, 2, 3, 4}) {
+		t.Errorf("To(5): %v", got)
 	}
-	if got := slices.Collect(s.AllBetween(3, 7)); !slices.Equal(got, []int{3, 4, 5, 6}) {
-		t.Errorf("AllBetween(3, 7): %v", got)
+	if got := slices.Collect(s.Between(4, 8)); !slices.Equal(got, []int{4, 5, 6, 7}) {
+		t.Errorf("Between(4, 8): %v", got)
 	}
 
 	// Early exit coverage
-	for k := range s.AllBetween(1, 10) {
+	for k := range s.Between(1, 10) {
 		_ = k
 		break
 	}


### PR DESCRIPTION
Rename iterators across all collections to adhere to the naming conventions outlined in the Go 1.23 iter package.