### PR TITLE
refactor: unexport Config to config across all packages

### DIFF
--- a/arraydeque/arraydeque.go
+++ b/arraydeque/arraydeque.go
@@ -33,13 +33,13 @@ type ArrayDeque[T any] struct {
 	size  int
 }
 
-// Config holds the values for configuring a ArrayDeque.
-type Config struct {
+// config holds the values for configuring a ArrayDeque.
+type config struct {
 	Capacity int
 }
 
 // Option configures a ArrayDeque config
-type Option func(*Config)
+type Option func(*config)
 
 // New creates an empty ArrayDeque whose initial size is 0.
 func New[T any](opts ...Option) *ArrayDeque[T] {
@@ -260,8 +260,8 @@ func (d *ArrayDeque[T]) resize() {
 	d.back = d.size
 }
 
-func defaultConfig() *Config {
-	return &Config{
+func defaultConfig() *config {
+	return &config{
 		Capacity: DefaultCapacity,
 	}
 }

--- a/arraydeque/arraydeque_bench_test.go
+++ b/arraydeque/arraydeque_bench_test.go
@@ -39,7 +39,7 @@ func BenchmarkArrayDeque_AddRemove(b *testing.B) {
 }
 
 func BenchmarkArrayDeque_AddFront_Preallocated(b *testing.B) {
-	d := New[int](func(c *Config) { c.Capacity = b.N })
+	d := New[int](func(c *config) { c.Capacity = b.N })
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		d.AddFront(i)
@@ -47,7 +47,7 @@ func BenchmarkArrayDeque_AddFront_Preallocated(b *testing.B) {
 }
 
 func BenchmarkArrayDeque_AddBack_Preallocated(b *testing.B) {
-	d := New[int](func(c *Config) { c.Capacity = b.N })
+	d := New[int](func(c *config) { c.Capacity = b.N })
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		d.AddBack(i)

--- a/arraydeque/arraydeque_test.go
+++ b/arraydeque/arraydeque_test.go
@@ -29,7 +29,7 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name: "zero_capacity",
-			opts: []Option{func(c *Config) { c.Capacity = 0 }},
+			opts: []Option{func(c *config) { c.Capacity = 0 }},
 			check: func(t *testing.T, d *ArrayDeque[int]) {
 				d.Add(1) // Should not panic
 				if size := d.Size(); size != 1 {

--- a/bitset/bitset.go
+++ b/bitset/bitset.go
@@ -25,17 +25,17 @@ type BitSet struct {
 
 var _ collections.MutableNavigableSet[int] = (*BitSet)(nil)
 
-// Config holds the values for configuring a BitSet.
-type Config struct {
+// config holds the values for configuring a BitSet.
+type config struct {
 	numBits int
 }
 
 // Option configures a BitSet config
-type Option func(*Config)
+type Option func(*config)
 
 // NumBits provides the option to set the number of bits used in a BitSet.
 func NumBits(n int) Option {
-	return func(c *Config) {
+	return func(c *config) {
 		c.numBits = n
 	}
 }
@@ -250,8 +250,8 @@ func convert(bit int) (int, int) {
 	return bit / wordSize, bit % wordSize
 }
 
-func defaultConfig() *Config {
-	return &Config{
+func defaultConfig() *config {
+	return &config{
 		numBits: DefaultNumBits,
 	}
 }

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -8,24 +8,24 @@ import (
 	"strings"
 )
 
-// Config holds configuration values for New to use when contracting a Graph.
-type Config struct {
+// config holds configuration values for New to use when contracting a Graph.
+type config struct {
 	delegateOps []labeledgraph.Opt
 }
 
 // Opt represents a configuration option for constructing a Graph.
-type Opt func(g *Config)
+type Opt func(g *config)
 
 // Directed is an option that configures New to return a directed graph.
 func Directed() Opt {
-	return func(g *Config) {
+	return func(g *config) {
 		g.delegateOps = append(g.delegateOps, labeledgraph.Directed())
 	}
 }
 
 // Capacity is an option that configures New to pre-allocate the graph with the given capacity.
 func Capacity(n int) Opt {
-	return func(g *Config) {
+	return func(g *config) {
 		g.delegateOps = append(g.delegateOps, labeledgraph.Capacity(n))
 	}
 }
@@ -208,6 +208,6 @@ func (g *Graph[V]) String() string {
 	return sb.String()
 }
 
-func defaultConfig() *Config {
-	return &Config{}
+func defaultConfig() *config {
+	return &config{}
 }

--- a/hashmap/hashmap.go
+++ b/hashmap/hashmap.go
@@ -14,24 +14,24 @@ type HashMap[K comparable, V any] struct {
 	m map[K]V
 }
 
-// Config holds the values for configuring a HashMap.
-type Config struct {
+// config holds the values for configuring a HashMap.
+type config struct {
 	capacity int
 }
 
 // Option configures a HashMap config
-type Option func(*Config)
+type Option func(*config)
 
 // WithCapacity configures the initial capacity of the HashMap.
 func WithCapacity(capacity int) Option {
-	return func(c *Config) {
+	return func(c *config) {
 		c.capacity = capacity
 	}
 }
 
 // New creates an empty HashMap.
 func New[K comparable, V any](opts ...Option) *HashMap[K, V] {
-	config := &Config{}
+	config := &config{}
 	for _, option := range opts {
 		option(config)
 	}

--- a/hashset/hashset.go
+++ b/hashset/hashset.go
@@ -16,17 +16,17 @@ type HashSet[T comparable] struct {
 	m map[T]struct{}
 }
 
-// Config holds the values for configuring a HashSet.
-type Config struct {
+// config holds the values for configuring a HashSet.
+type config struct {
 	capacity int
 }
 
 // Option configures a HashSet config
-type Option func(*Config)
+type Option func(*config)
 
 // WithCapacity configures the initial capacity of the HashSet.
 func WithCapacity(capacity int) Option {
-	return func(c *Config) {
+	return func(c *config) {
 		c.capacity = capacity
 	}
 }
@@ -118,6 +118,6 @@ func (s *HashSet[T]) All() iter.Seq[T] {
 	return maps.Keys(s.m)
 }
 
-func defaultConfig() *Config {
-	return &Config{}
+func defaultConfig() *config {
+	return &config{}
 }

--- a/heap/heap.go
+++ b/heap/heap.go
@@ -16,24 +16,24 @@ const (
 var _ collections.MutableQueue[int] = (*Heap[int])(nil)
 
 // Option is a function that configures a Heap.
-type Option[T any] func(config *Config[T])
+type Option[T any] func(config *config[T])
 
-// Config holds the configuration for a Heap.
-type Config[T any] struct {
+// config holds the configuration for a Heap.
+type config[T any] struct {
 	capacity   int
 	comparator comparator.Comparator[T]
 }
 
 // WithComparator configures the comparator used by the Heap.
 func WithComparator[T any](cmpFunc comparator.Comparator[T]) Option[T] {
-	return func(config *Config[T]) {
+	return func(config *config[T]) {
 		config.comparator = cmpFunc
 	}
 }
 
 // Capacity configures the initial pre-allocated capacity of the heap.
 func Capacity[T any](capacity int) Option[T] {
-	return func(config *Config[T]) {
+	return func(config *config[T]) {
 		config.capacity = capacity
 	}
 }
@@ -120,8 +120,8 @@ func (h *Heap[T]) All() iter.Seq[T] {
 
 // Private Functions
 
-func defaultConfig[T any]() *Config[T] {
-	return &Config[T]{
+func defaultConfig[T any]() *config[T] {
+	return &config[T]{
 		capacity: DefaultCapacity,
 	}
 }

--- a/labeledgraph/labeledgraph.go
+++ b/labeledgraph/labeledgraph.go
@@ -9,25 +9,25 @@ import (
 	"strings"
 )
 
-// Config holds configuration values for New to use when contracting a LabeledGraph.
-type Config struct {
+// config holds configuration values for New to use when contracting a LabeledGraph.
+type config struct {
 	directed bool
 	capacity int
 }
 
 // Opt represents a configuration option for constructing a LabeledGraph.
-type Opt func(g *Config)
+type Opt func(g *config)
 
 // Directed is an option that configures New to return a directed graph.
 func Directed() Opt {
-	return func(g *Config) {
+	return func(g *config) {
 		g.directed = true
 	}
 }
 
 // Capacity is an option that configures New to pre-allocate the graph with the given capacity.
 func Capacity(n int) Opt {
-	return func(g *Config) {
+	return func(g *config) {
 		g.capacity = n
 	}
 }
@@ -438,8 +438,8 @@ func (g *LabeledGraph[V, L]) nodeData() nodeData[V, L] {
 	}
 }
 
-func defaultConfig() *Config {
-	return &Config{
+func defaultConfig() *config {
+	return &config{
 		directed: false,
 	}
 }

--- a/linkedhashmap/linkedhashmap.go
+++ b/linkedhashmap/linkedhashmap.go
@@ -17,40 +17,40 @@ var _ collections.MutableSequencedMap[int, int] = (*LinkedHashMap[int, int])(nil
 // KeyOrder represents the iteration order of the linked hash map.
 type KeyOrder bool
 
-// Config holds the configuration for a LinkedHashMap.
-type Config struct {
+// config holds the configuration for a LinkedHashMap.
+type config struct {
 	keyOrder    KeyOrder
 	maxElements int
 	capacity    int
 }
 
 // Opt is a function that configures a LinkedHashMap.
-type Opt func(*Config)
+type Opt func(*config)
 
 // WithAccessOrder configures the LinkedHashMap to iterate over elements in the order they were last accessed.
 func WithAccessOrder() Opt {
-	return func(config *Config) {
+	return func(config *config) {
 		config.keyOrder = AccessOrder
 	}
 }
 
 // WithInsertionOrder configures the LinkedHashMap to iterate over elements in the order they were inserted.
 func WithInsertionOrder() Opt {
-	return func(config *Config) {
+	return func(config *config) {
 		config.keyOrder = InsertionOrder
 	}
 }
 
 // WithMaxElements configures the maximum number of elements the LinkedHashMap can hold before evicting.
 func WithMaxElements(max int) Opt {
-	return func(config *Config) {
+	return func(config *config) {
 		config.maxElements = max
 	}
 }
 
 // WithCapacity configures the initial capacity of the underlying map.
 func WithCapacity(capacity int) Opt {
-	return func(config *Config) {
+	return func(config *config) {
 		config.capacity = capacity
 	}
 }
@@ -276,8 +276,8 @@ func (hm *LinkedHashMap[K, V]) removeEldest() bool {
 	return hm.Size() > hm.maxElements
 }
 
-func defaultConfig() *Config {
-	return &Config{
+func defaultConfig() *config {
+	return &config{
 		keyOrder:    false,
 		maxElements: math.MaxInt,
 	}

--- a/treemap/treemap.go
+++ b/treemap/treemap.go
@@ -11,25 +11,25 @@ const (
 	DefaultDegree = 32
 )
 
-// Config holds the values for configuring a TreeMap.
-type Config[K any] struct {
+// config holds the values for configuring a TreeMap.
+type config[K any] struct {
 	degree     int
 	comparator comparator.Comparator[K]
 }
 
 // Option configures a TreeMap config
-type Option[K any] func(*Config[K])
+type Option[K any] func(*config[K])
 
 // WithDegree configures the minimum degree of the B-Tree.
 func WithDegree[K any](degree int) Option[K] {
-	return func(c *Config[K]) {
+	return func(c *config[K]) {
 		c.degree = degree
 	}
 }
 
 // WithComparator configures the comparator used by the TreeMap.
 func WithComparator[K any](cmpFunc comparator.Comparator[K]) Option[K] {
-	return func(c *Config[K]) {
+	return func(c *config[K]) {
 		c.comparator = cmpFunc
 	}
 }
@@ -44,7 +44,7 @@ type TreeMap[K any, V any] struct {
 
 // New creates an empty TreeMap with the given options.
 func New[K any, V any](opts ...Option[K]) *TreeMap[K, V] {
-	config := &Config[K]{
+	config := &config[K]{
 		degree: DefaultDegree,
 	}
 	for _, option := range opts {

--- a/treeset/treeset.go
+++ b/treeset/treeset.go
@@ -11,32 +11,32 @@ type TreeSet[T any] struct {
 	m *treemap.TreeMap[T, struct{}]
 }
 
-// Config holds the values for configuring a TreeSet.
-type Config[T any] struct {
+// config holds the values for configuring a TreeSet.
+type config[T any] struct {
 	degree     *int
 	comparator comparator.Comparator[T]
 }
 
 // Option configures a TreeSet config.
-type Option[T any] func(*Config[T])
+type Option[T any] func(*config[T])
 
 // WithDegree configures the degree of the underlying B-Tree.
 func WithDegree[T any](degree int) Option[T] {
-	return func(c *Config[T]) {
+	return func(c *config[T]) {
 		c.degree = &degree
 	}
 }
 
 // WithComparator configures the comparator for the TreeSet.
 func WithComparator[T any](comp comparator.Comparator[T]) Option[T] {
-	return func(c *Config[T]) {
+	return func(c *config[T]) {
 		c.comparator = comp
 	}
 }
 
 // New creates an empty TreeSet.
 func New[T any](opts ...Option[T]) *TreeSet[T] {
-	config := &Config[T]{}
+	config := &config[T]{}
 	for _, option := range opts {
 		option(config)
 	}


### PR DESCRIPTION
Unexports the Config struct across all packages since its fields are private and it cannot be used meaningfully by consumers of the library.