### PR TITLE
feat(trie): add trie package with Map and Set interfaces

### DIFF
--- a/trie/coverage_patch_test.go
+++ b/trie/coverage_patch_test.go
@@ -1,0 +1,85 @@
+package trie
+
+import (
+	"testing"
+)
+
+func TestCoveragePatch(t *testing.T) {
+	sm := NewSliceMap[byte, int]()
+	m := NewMap[int]()
+
+	// 1. LongestPrefixOf on empty slice
+	slk, slv, slok := sm.LongestPrefixOf([]byte("xyz"))
+	if slok || len(slk) != 0 || slv != 0 {
+		t.Errorf("LongestPrefixOf empty slice failed")
+	}
+
+	// 2. Remove root values
+	m.Put("", 1)
+	m.Remove("")
+	if m.Size() != 0 {
+		t.Errorf("Remove empty string failed")
+	}
+
+	sm.Put([]byte{}, 1)
+	sm.Remove([]byte{})
+	if sm.Size() != 0 {
+		t.Errorf("Remove empty slice failed")
+	}
+
+	// 3. Remove non-existent long keys to hit removeNode nil children / missing key
+	m.Remove("ab")
+	m.Remove("xyz")
+	sm.Remove([]byte("ab"))
+	sm.Remove([]byte("xyz"))
+
+	// 4. Empty trie HasPrefix
+	emptyStrMap := NewMap[int]()
+	if emptyStrMap.HasPrefix("") {
+		t.Errorf("empty map should not have empty prefix")
+	}
+	emptySliceMap := NewSliceMap[byte, int]()
+	if emptySliceMap.HasPrefix([]byte{}) {
+		t.Errorf("empty slice map should not have empty prefix")
+	}
+
+	// 5. EntriesWithPrefix early exit
+	m.Put("abc", 1)
+	count := 0
+	for range m.EntriesWithPrefix("a") {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("EntriesWithPrefix early exit failed")
+	}
+
+	sm.Put([]byte("abc"), 1)
+	count = 0
+	for range sm.EntriesWithPrefix([]byte("a")) {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("EntriesWithPrefix early exit failed")
+	}
+
+	// 6. PrefixesOf early exit
+	count = 0
+	for range m.PrefixesOf("abc") {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("PrefixesOf early exit failed")
+	}
+
+	count = 0
+	for range sm.PrefixesOf([]byte("abc")) {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("PrefixesOf early exit failed")
+	}
+}

--- a/trie/coverage_patch_test.go
+++ b/trie/coverage_patch_test.go
@@ -82,4 +82,68 @@ func TestCoveragePatch(t *testing.T) {
 	if count != 1 {
 		t.Errorf("PrefixesOf early exit failed")
 	}
+
+	count = 0
+	for range sm.PrefixesOf([]byte("abc")) {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("PrefixesOf early exit failed")
+	}
+
+	// 7. Set interface methods coverage
+	ss1 := NewSliceSet[byte]()
+	ss2 := NewSliceSet[byte]()
+	ss2.Add([]byte("a"))
+	ss2.Add([]byte("b"))
+
+	ss1.AddAll(ss2.All())
+	if !ss1.ContainsAll(ss2) {
+		t.Errorf("ContainsAll failed")
+	}
+
+	ss1.RemoveAll(ss2)
+	if ss1.Size() != 0 {
+		t.Errorf("RemoveAll failed")
+	}
+
+	ss1.Add([]byte("a"))
+	ss1.Add([]byte("b"))
+	ss1.Add([]byte("c"))
+	ss3 := NewSliceSet[byte]()
+	ss3.Add([]byte("a"))
+	ss1.RetainAll(ss3)
+	if ss1.Size() != 1 || !ss1.Contains([]byte("a")) {
+		t.Errorf("RetainAll failed")
+	}
+
+	ss1.RemoveElement([]byte("a"))
+	if ss1.Size() != 0 {
+		t.Errorf("Remove failed")
+	}
+
+	// String set methods
+	strSet1 := NewSet()
+	strSet2 := NewSet()
+	strSet2.Add("a")
+	strSet1.AddAll(strSet2.All())
+	if !strSet1.ContainsAll(strSet2) {
+		t.Errorf("ContainsAll string failed")
+	}
+
+	// 8. PrefixesOf missing cases
+	sm2 := NewSliceMap[byte, int]()
+	sm2.Put([]byte("a"), 1)
+	for range sm2.PrefixesOf([]byte("ab")) {
+	} // no break
+
+	sm3 := NewMap[int]()
+	sm3.Put("a", 1)
+	for range sm3.PrefixesOf("ab") {
+	} // no break
+
+	// 9. ShortestPrefixOf missing cases
+	sm2.ShortestPrefixOf([]byte("x"))
+	sm3.ShortestPrefixOf("x")
 }

--- a/trie/example_test.go
+++ b/trie/example_test.go
@@ -1,0 +1,74 @@
+package trie_test
+
+import (
+	"fmt"
+
+	"github.com/lock14/collections/trie"
+)
+
+func ExampleNewMap() {
+	m := trie.NewMap[int]()
+
+	m.Put("apple", 1)
+	m.Put("app", 2)
+	m.Put("ape", 3)
+	m.Put("bat", 4)
+
+	v, ok := m.Get("app")
+	fmt.Printf("Get('app'): %d, %v\n", v, ok)
+
+	fmt.Printf("Size: %d\n", m.Size())
+
+	// Output:
+	// Get('app'): 2, true
+	// Size: 4
+}
+
+func ExampleMap_KeysWithPrefix() {
+	m := trie.NewMap[int]()
+
+	m.Put("apple", 1)
+	m.Put("app", 2)
+	m.Put("ape", 3)
+	m.Put("bat", 4)
+
+	fmt.Println("Keys with prefix 'ap':")
+	for k := range m.KeysWithPrefix("ap") {
+		fmt.Println(k)
+	}
+
+	// Output:
+	// Keys with prefix 'ap':
+	// ape
+	// app
+	// apple
+}
+
+func ExampleMap_LongestPrefixOf() {
+	m := trie.NewMap[int]()
+
+	// E.g., setting up routing rules
+	m.Put("/api/", 1)
+	m.Put("/api/v1/", 2)
+	m.Put("/api/v1/users", 3)
+
+	query := "/api/v1/users/123/profile"
+	k, v, ok := m.LongestPrefixOf(query)
+	fmt.Printf("Matched route: %s (value %d, found %v)\n", k, v, ok)
+
+	// Output:
+	// Matched route: /api/v1/users (value 3, found true)
+}
+
+func ExampleNewSliceMap() {
+	m := trie.NewSliceMap[byte, string]()
+
+	m.Put([]byte{192, 168, 0, 1}, "router")
+	m.Put([]byte{192, 168, 0, 100}, "laptop")
+
+	k, v, ok := m.LongestPrefixOf([]byte{192, 168, 0, 100, 255})
+	fmt.Printf("Matched: %v -> %s (found: %v)\n", k, v, ok)
+
+	// Output:
+	// Matched: [192 168 0 100] -> laptop (found: true)
+}

--- a/trie/slice.go
+++ b/trie/slice.go
@@ -1,0 +1,481 @@
+package trie
+
+import (
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/lock14/collections"
+)
+
+var _ Map[[]int, int] = (*sliceMap[int, int])(nil)
+
+type sliceNode[E comparable, V any] struct {
+	children map[E]*sliceNode[E, V]
+	value    V
+	hasValue bool
+}
+
+type sliceMap[E comparable, V any] struct {
+	root *sliceNode[E, V]
+	size int
+}
+
+func newSliceMap[E comparable, V any]() *sliceMap[E, V] {
+	return &sliceMap[E, V]{
+		root: &sliceNode[E, V]{},
+	}
+}
+
+func (m *sliceMap[E, V]) Get(key []E) (V, bool) {
+	node := m.getNode(key)
+	if node != nil {
+		return node.value, node.hasValue
+	}
+	var zero V
+	return zero, false
+}
+
+func (m *sliceMap[E, V]) Put(key []E, value V) {
+	node := m.root
+	for i := 0; i < len(key); i++ {
+		if node.children == nil {
+			node.children = make(map[E]*sliceNode[E, V])
+		}
+		b := key[i]
+		next, ok := node.children[b]
+		if !ok {
+			next = &sliceNode[E, V]{}
+			node.children[b] = next
+		}
+		node = next
+	}
+	if !node.hasValue {
+		m.size++
+		node.hasValue = true
+	}
+	node.value = value
+}
+
+func (m *sliceMap[E, V]) Remove(key []E) {
+	if m.removeNode(m.root, key, 0) {
+		m.size--
+	}
+}
+
+func (m *sliceMap[E, V]) removeNode(node *sliceNode[E, V], key []E, depth int) bool {
+	if depth == len(key) {
+		if !node.hasValue {
+			return false
+		}
+		node.hasValue = false
+		var zero V
+		node.value = zero
+		return true
+	}
+	if node.children == nil {
+		return false
+	}
+	b := key[depth]
+	next, ok := node.children[b]
+	if !ok {
+		return false
+	}
+	removed := m.removeNode(next, key, depth+1)
+	if removed {
+		if !next.hasValue && len(next.children) == 0 {
+			delete(node.children, b)
+		}
+	}
+	return removed
+}
+
+func (m *sliceMap[E, V]) Size() int {
+	return m.size
+}
+
+func (m *sliceMap[E, V]) Empty() bool {
+	return m.size == 0
+}
+
+func (m *sliceMap[E, V]) Clear() {
+	m.root = &sliceNode[E, V]{}
+	m.size = 0
+}
+
+func (m *sliceMap[E, V]) ContainsKey(key []E) bool {
+	node := m.getNode(key)
+	return node != nil && node.hasValue
+}
+
+func (m *sliceMap[E, V]) All() iter.Seq2[[]E, V] {
+	return func(yield func([]E, V) bool) {
+		m.iterate(m.root, nil, yield)
+	}
+}
+
+func (m *sliceMap[E, V]) Keys() iter.Seq[[]E] {
+	return func(yield func([]E) bool) {
+		for k := range m.All() {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func (m *sliceMap[E, V]) Values() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, v := range m.All() {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+func cloneSlice[E any](s []E) []E {
+	if s == nil {
+		return nil
+	}
+	c := make([]E, len(s))
+	copy(c, s)
+	return c
+}
+
+// iterate performs a DFS. Iteration order is not guaranteed because map iteration is random.
+func (m *sliceMap[E, V]) iterate(node *sliceNode[E, V], prefix []E, yield func([]E, V) bool) bool {
+	if node.hasValue {
+		// Yield a cloned slice so the caller cannot modify our internal state or see changes from subsequent iterations.
+		if !yield(cloneSlice(prefix), node.value) {
+			return false
+		}
+	}
+	if node.children != nil {
+		for k, next := range node.children {
+			// prefix[:len(prefix):len(prefix)] forces append to allocate a new underlying array
+			if !m.iterate(next, append(prefix[:len(prefix):len(prefix)], k), yield) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (m *sliceMap[E, V]) getNode(prefix []E) *sliceNode[E, V] {
+	node := m.root
+	for i := 0; i < len(prefix); i++ {
+		if node.children == nil {
+			return nil
+		}
+		next, ok := node.children[prefix[i]]
+		if !ok {
+			return nil
+		}
+		node = next
+	}
+	return node
+}
+
+func (m *sliceMap[E, V]) HasPrefix(prefix []E) bool {
+	node := m.getNode(prefix)
+	if node == nil {
+		return false
+	}
+	return m.hasAnyValue(node)
+}
+
+func (m *sliceMap[E, V]) hasAnyValue(node *sliceNode[E, V]) bool {
+	if node.hasValue {
+		return true
+	}
+	for _, child := range node.children {
+		if m.hasAnyValue(child) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *sliceMap[E, V]) EntriesWithPrefix(prefix []E) iter.Seq2[[]E, V] {
+	return func(yield func([]E, V) bool) {
+		node := m.getNode(prefix)
+		if node == nil {
+			return
+		}
+		m.iterate(node, prefix, yield)
+	}
+}
+
+func (m *sliceMap[E, V]) KeysWithPrefix(prefix []E) iter.Seq[[]E] {
+	return func(yield func([]E) bool) {
+		for k := range m.EntriesWithPrefix(prefix) {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func (m *sliceMap[E, V]) ValuesWithPrefix(prefix []E) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, v := range m.EntriesWithPrefix(prefix) {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+func (m *sliceMap[E, V]) RemovePrefix(prefix []E) {
+	if len(prefix) == 0 {
+		m.Clear()
+		return
+	}
+	m.removePrefixNode(m.root, prefix, 0)
+}
+
+func (m *sliceMap[E, V]) countValues(node *sliceNode[E, V]) int {
+	if node == nil {
+		return 0
+	}
+	count := 0
+	if node.hasValue {
+		count++
+	}
+	for _, child := range node.children {
+		count += m.countValues(child)
+	}
+	return count
+}
+
+func (m *sliceMap[E, V]) removePrefixNode(node *sliceNode[E, V], prefix []E, depth int) bool {
+	if depth == len(prefix)-1 {
+		if node.children == nil {
+			return false
+		}
+		b := prefix[depth]
+		target, ok := node.children[b]
+		if !ok {
+			return false
+		}
+		removedCount := m.countValues(target)
+		m.size -= removedCount
+		delete(node.children, b)
+		return true
+	}
+	if node.children == nil {
+		return false
+	}
+	b := prefix[depth]
+	next, ok := node.children[b]
+	if !ok {
+		return false
+	}
+	removed := m.removePrefixNode(next, prefix, depth+1)
+	if removed {
+		if !next.hasValue && len(next.children) == 0 {
+			delete(node.children, b)
+		}
+	}
+	return removed
+}
+
+func (m *sliceMap[E, V]) LongestPrefixOf(query []E) ([]E, V, bool) {
+	node := m.root
+	var longestKey []E
+	var longestVal V
+	var found bool
+
+	if node.hasValue {
+		longestKey = nil
+		longestVal = node.value
+		found = true
+	}
+
+	for i := 0; i < len(query); i++ {
+		if node.children == nil {
+			break
+		}
+		next, ok := node.children[query[i]]
+		if !ok {
+			break
+		}
+		node = next
+		if node.hasValue {
+			longestKey = cloneSlice(query[:i+1])
+			longestVal = node.value
+			found = true
+		}
+	}
+	return longestKey, longestVal, found
+}
+
+func (m *sliceMap[E, V]) ShortestPrefixOf(query []E) ([]E, V, bool) {
+	node := m.root
+	if node.hasValue {
+		return nil, node.value, true
+	}
+	for i := 0; i < len(query); i++ {
+		if node.children == nil {
+			break
+		}
+		next, ok := node.children[query[i]]
+		if !ok {
+			break
+		}
+		node = next
+		if node.hasValue {
+			return cloneSlice(query[:i+1]), node.value, true
+		}
+	}
+	var zero V
+	return nil, zero, false
+}
+
+func (m *sliceMap[E, V]) PrefixesOf(query []E) iter.Seq2[[]E, V] {
+	return func(yield func([]E, V) bool) {
+		node := m.root
+		if node.hasValue {
+			if !yield(nil, node.value) {
+				return
+			}
+		}
+		for i := 0; i < len(query); i++ {
+			if node.children == nil {
+				break
+			}
+			next, ok := node.children[query[i]]
+			if !ok {
+				break
+			}
+			node = next
+			if node.hasValue {
+				if !yield(cloneSlice(query[:i+1]), node.value) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// SliceSet Implementation
+// -----------------------------------------------------------------------------
+
+var _ Set[[]int] = (*sliceSet[int])(nil)
+
+type sliceSet[E comparable] struct {
+	m *sliceMap[E, struct{}]
+}
+
+func newSliceSet[E comparable]() *sliceSet[E] {
+	return &sliceSet[E]{m: newSliceMap[E, struct{}]()}
+}
+
+func (s *sliceSet[E]) Size() int {
+	return s.m.Size()
+}
+
+func (s *sliceSet[E]) Empty() bool {
+	return s.m.Empty()
+}
+
+func (s *sliceSet[E]) Clear() {
+	s.m.Clear()
+}
+
+func (s *sliceSet[E]) All() iter.Seq[[]E] {
+	return s.m.Keys()
+}
+
+func (s *sliceSet[E]) Add(item []E) {
+	s.m.Put(item, struct{}{})
+}
+
+func (s *sliceSet[E]) Remove() []E {
+	for k := range s.m.Keys() {
+		s.m.Remove(k)
+		return k
+	}
+	panic("cannot remove from an empty set")
+}
+
+func (s *sliceSet[E]) AddAll(sequence iter.Seq[[]E]) {
+	for t := range sequence {
+		s.Add(t)
+	}
+}
+
+func (s *sliceSet[E]) RemoveElement(item []E) {
+	s.m.Remove(item)
+}
+
+func (s *sliceSet[E]) RemoveAll(other collections.Collection[[]E]) {
+	for t := range other.All() {
+		s.RemoveElement(t)
+	}
+}
+
+func (s *sliceSet[E]) RetainAll(other collections.Collection[[]E]) {
+	newMap := newSliceMap[E, struct{}]()
+	for t := range other.All() {
+		if s.Contains(t) {
+			newMap.Put(t, struct{}{})
+		}
+	}
+	s.m = newMap
+}
+
+func (s *sliceSet[E]) Contains(item []E) bool {
+	return s.m.ContainsKey(item)
+}
+
+func (s *sliceSet[E]) ContainsAll(other collections.Collection[[]E]) bool {
+	for item := range other.All() {
+		if !s.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *sliceSet[E]) HasPrefix(prefix []E) bool {
+	return s.m.HasPrefix(prefix)
+}
+
+func (s *sliceSet[E]) ElementsWithPrefix(prefix []E) iter.Seq[[]E] {
+	return s.m.KeysWithPrefix(prefix)
+}
+
+func (s *sliceSet[E]) RemovePrefix(prefix []E) {
+	s.m.RemovePrefix(prefix)
+}
+
+func (s *sliceSet[E]) LongestPrefixOf(query []E) ([]E, bool) {
+	k, _, ok := s.m.LongestPrefixOf(query)
+	return k, ok
+}
+
+func (s *sliceSet[E]) ShortestPrefixOf(query []E) ([]E, bool) {
+	k, _, ok := s.m.ShortestPrefixOf(query)
+	return k, ok
+}
+
+func (s *sliceSet[E]) PrefixesOf(query []E) iter.Seq[[]E] {
+	return func(yield func([]E) bool) {
+		for k := range s.m.PrefixesOf(query) {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func (s *sliceSet[E]) String() string {
+	vals := make([]string, 0, s.Size())
+	for item := range s.All() {
+		vals = append(vals, fmt.Sprintf("%+v", item))
+	}
+	return "[" + strings.Join(vals, ", ") + "]"
+}

--- a/trie/slice_test.go
+++ b/trie/slice_test.go
@@ -1,0 +1,225 @@
+package trie
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+func TestSliceMap_Comprehensive(t *testing.T) {
+	m := NewSliceMap[byte, int]()
+
+	// Test Empty, Size, Clear
+	if !m.Empty() {
+		t.Errorf("expected empty")
+	}
+	m.Put([]byte("hello"), 1)
+	m.Put([]byte("world"), 2)
+
+	if m.Size() != 2 {
+		t.Errorf("expected size 2")
+	}
+
+	m.Clear()
+	if !m.Empty() {
+		t.Errorf("expected empty after clear")
+	}
+
+	m.Put([]byte("app"), 1)
+	m.Put([]byte("apple"), 2)
+	m.Put([]byte("ape"), 3)
+
+	// Test ContainsKey, Get
+	if !m.ContainsKey([]byte("app")) {
+		t.Errorf("expected to contain app")
+	}
+	v, ok := m.Get([]byte("apple"))
+	if !ok || v != 2 {
+		t.Errorf("Get failed")
+	}
+
+	// Test Remove
+	m.Remove([]byte("ape"))
+	if m.ContainsKey([]byte("ape")) {
+		t.Errorf("expected ape to be removed")
+	}
+
+	// Test Prefix Operations
+	if !m.HasPrefix([]byte("ap")) {
+		t.Errorf("expected HasPrefix true")
+	}
+
+	keys := slices.Collect(m.KeysWithPrefix([]byte("app")))
+	if len(keys) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(keys))
+	}
+
+	vals := slices.Collect(m.ValuesWithPrefix([]byte("app")))
+	if len(vals) != 2 {
+		t.Errorf("expected 2 vals, got %d", len(vals))
+	}
+
+	entries := make(map[string]int)
+	for k, v := range m.EntriesWithPrefix([]byte("app")) {
+		entries[string(k)] = v
+	}
+	if entries["app"] != 1 || entries["apple"] != 2 {
+		t.Errorf("EntriesWithPrefix failed")
+	}
+
+	lk, lv, lok := m.LongestPrefixOf([]byte("apple pie"))
+	if !lok || string(lk) != "apple" || lv != 2 {
+		t.Errorf("LongestPrefixOf failed")
+	}
+
+	sk, sv, sok := m.ShortestPrefixOf([]byte("apple pie"))
+	if !sok || string(sk) != "app" || sv != 1 {
+		t.Errorf("ShortestPrefixOf failed")
+	}
+
+	var prefixes []string
+	for k := range m.PrefixesOf([]byte("apple pie")) {
+		prefixes = append(prefixes, string(k))
+	}
+	if len(prefixes) != 2 {
+		t.Errorf("PrefixesOf failed")
+	}
+
+	// Test RemovePrefix
+	m.RemovePrefix([]byte("ap"))
+	if !m.Empty() {
+		t.Errorf("expected empty after RemovePrefix")
+	}
+}
+
+func TestSliceSet_Comprehensive(t *testing.T) {
+	s := NewSliceSet[byte]()
+
+	s.Add([]byte("hello"))
+	s.Add([]byte("world"))
+
+	if s.Size() != 2 {
+		t.Errorf("expected size 2")
+	}
+	if !s.Contains([]byte("hello")) {
+		t.Errorf("expected Contains true")
+	}
+
+	s.RemoveElement([]byte("world"))
+	if s.Contains([]byte("world")) {
+		t.Errorf("expected world to be removed")
+	}
+
+	s.Clear()
+	if !s.Empty() {
+		t.Errorf("expected empty")
+	}
+
+	s.Add([]byte("app"))
+	s.Add([]byte("apple"))
+
+	if !s.HasPrefix([]byte("ap")) {
+		t.Errorf("expected HasPrefix true")
+	}
+
+	keys := slices.Collect(s.ElementsWithPrefix([]byte("app")))
+	if len(keys) != 2 {
+		t.Errorf("expected 2 keys")
+	}
+
+	lk, lok := s.LongestPrefixOf([]byte("apple pie"))
+	if !lok || string(lk) != "apple" {
+		t.Errorf("LongestPrefixOf failed")
+	}
+
+	sk, sok := s.ShortestPrefixOf([]byte("apple pie"))
+	if !sok || string(sk) != "app" {
+		t.Errorf("ShortestPrefixOf failed")
+	}
+
+	var prefixes []string
+	for k := range s.PrefixesOf([]byte("apple pie")) {
+		prefixes = append(prefixes, string(k))
+	}
+	if len(prefixes) != 2 {
+		t.Errorf("PrefixesOf failed")
+	}
+
+	s.RemovePrefix([]byte("ap"))
+	if !s.Empty() {
+		t.Errorf("expected empty after RemovePrefix")
+	}
+
+	// Test String()
+	s.Add([]byte("x"))
+	str := fmt.Sprintf("%s", s)
+	if str != "[[120]]" {
+		t.Errorf("String failed, got %s", str)
+	}
+}
+
+func TestStringSet_Comprehensive(t *testing.T) {
+	s := NewSet()
+
+	s.Add("hello")
+	s.Add("world")
+
+	if s.Size() != 2 {
+		t.Errorf("expected size 2")
+	}
+	if !s.Contains("hello") {
+		t.Errorf("expected Contains true")
+	}
+
+	s.RemoveElement("world")
+	if s.Contains("world") {
+		t.Errorf("expected world to be removed")
+	}
+
+	s.Clear()
+	if !s.Empty() {
+		t.Errorf("expected empty")
+	}
+
+	s.Add("app")
+	s.Add("apple")
+
+	if !s.HasPrefix("ap") {
+		t.Errorf("expected HasPrefix true")
+	}
+
+	keys := slices.Collect(s.ElementsWithPrefix("app"))
+	if len(keys) != 2 {
+		t.Errorf("expected 2 keys")
+	}
+
+	lk, lok := s.LongestPrefixOf("apple pie")
+	if !lok || lk != "apple" {
+		t.Errorf("LongestPrefixOf failed")
+	}
+
+	sk, sok := s.ShortestPrefixOf("apple pie")
+	if !sok || sk != "app" {
+		t.Errorf("ShortestPrefixOf failed")
+	}
+
+	var prefixes []string
+	for k := range s.PrefixesOf("apple pie") {
+		prefixes = append(prefixes, string(k))
+	}
+	if len(prefixes) != 2 {
+		t.Errorf("PrefixesOf failed")
+	}
+
+	s.RemovePrefix("ap")
+	if !s.Empty() {
+		t.Errorf("expected empty after RemovePrefix")
+	}
+
+	// Test String()
+	s.Add("x")
+	str := fmt.Sprintf("%s", s)
+	if str != "[x]" {
+		t.Errorf("String failed, got %s", str)
+	}
+}

--- a/trie/string.go
+++ b/trie/string.go
@@ -1,0 +1,473 @@
+package trie
+
+import (
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/lock14/collections"
+)
+
+var _ Map[string, int] = (*stringMap[int])(nil)
+
+type stringNode[V any] struct {
+	children map[byte]*stringNode[V]
+	value    V
+	hasValue bool
+}
+
+type stringMap[V any] struct {
+	root *stringNode[V]
+	size int
+}
+
+func newStringMap[V any]() *stringMap[V] {
+	return &stringMap[V]{
+		root: &stringNode[V]{},
+	}
+}
+
+func (m *stringMap[V]) Get(key string) (V, bool) {
+	node := m.getNode(key)
+	if node != nil {
+		return node.value, node.hasValue
+	}
+	var zero V
+	return zero, false
+}
+
+func (m *stringMap[V]) Put(key string, value V) {
+	node := m.root
+	for i := 0; i < len(key); i++ {
+		if node.children == nil {
+			node.children = make(map[byte]*stringNode[V])
+		}
+		b := key[i]
+		next, ok := node.children[b]
+		if !ok {
+			next = &stringNode[V]{}
+			node.children[b] = next
+		}
+		node = next
+	}
+	if !node.hasValue {
+		m.size++
+		node.hasValue = true
+	}
+	node.value = value
+}
+
+func (m *stringMap[V]) Remove(key string) {
+	if m.removeNode(m.root, key, 0) {
+		m.size--
+	}
+}
+
+func (m *stringMap[V]) removeNode(node *stringNode[V], key string, depth int) bool {
+	if depth == len(key) {
+		if !node.hasValue {
+			return false
+		}
+		node.hasValue = false
+		var zero V
+		node.value = zero
+		return true
+	}
+	if node.children == nil {
+		return false
+	}
+	b := key[depth]
+	next, ok := node.children[b]
+	if !ok {
+		return false
+	}
+	removed := m.removeNode(next, key, depth+1)
+	if removed {
+		if !next.hasValue && len(next.children) == 0 {
+			delete(node.children, b)
+		}
+	}
+	return removed
+}
+
+func (m *stringMap[V]) Size() int {
+	return m.size
+}
+
+func (m *stringMap[V]) Empty() bool {
+	return m.size == 0
+}
+
+func (m *stringMap[V]) Clear() {
+	m.root = &stringNode[V]{}
+	m.size = 0
+}
+
+func (m *stringMap[V]) ContainsKey(key string) bool {
+	node := m.getNode(key)
+	return node != nil && node.hasValue
+}
+
+func (m *stringMap[V]) All() iter.Seq2[string, V] {
+	return func(yield func(string, V) bool) {
+		m.iterate(m.root, nil, yield)
+	}
+}
+
+func (m *stringMap[V]) Keys() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for k := range m.All() {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func (m *stringMap[V]) Values() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, v := range m.All() {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+// iterate performs a DFS and iterates over the nodes in lexicographical order.
+func (m *stringMap[V]) iterate(node *stringNode[V], prefix []byte, yield func(string, V) bool) bool {
+	if node.hasValue {
+		if !yield(string(prefix), node.value) {
+			return false
+		}
+	}
+	if node.children != nil {
+		for i := 0; i < 256; i++ {
+			b := byte(i)
+			if next, ok := node.children[b]; ok {
+				if !m.iterate(next, append(prefix, b), yield) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func (m *stringMap[V]) getNode(prefix string) *stringNode[V] {
+	node := m.root
+	for i := 0; i < len(prefix); i++ {
+		if node.children == nil {
+			return nil
+		}
+		next, ok := node.children[prefix[i]]
+		if !ok {
+			return nil
+		}
+		node = next
+	}
+	return node
+}
+
+func (m *stringMap[V]) HasPrefix(prefix string) bool {
+	node := m.getNode(prefix)
+	if node == nil {
+		return false
+	}
+	return m.hasAnyValue(node)
+}
+
+func (m *stringMap[V]) hasAnyValue(node *stringNode[V]) bool {
+	if node.hasValue {
+		return true
+	}
+	for _, child := range node.children {
+		if m.hasAnyValue(child) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *stringMap[V]) EntriesWithPrefix(prefix string) iter.Seq2[string, V] {
+	return func(yield func(string, V) bool) {
+		node := m.getNode(prefix)
+		if node == nil {
+			return
+		}
+		m.iterate(node, []byte(prefix), yield)
+	}
+}
+
+func (m *stringMap[V]) KeysWithPrefix(prefix string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for k := range m.EntriesWithPrefix(prefix) {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func (m *stringMap[V]) ValuesWithPrefix(prefix string) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, v := range m.EntriesWithPrefix(prefix) {
+			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+func (m *stringMap[V]) RemovePrefix(prefix string) {
+	if prefix == "" {
+		m.Clear()
+		return
+	}
+	m.removePrefixNode(m.root, prefix, 0)
+}
+
+func (m *stringMap[V]) countValues(node *stringNode[V]) int {
+	if node == nil {
+		return 0
+	}
+	count := 0
+	if node.hasValue {
+		count++
+	}
+	for _, child := range node.children {
+		count += m.countValues(child)
+	}
+	return count
+}
+
+func (m *stringMap[V]) removePrefixNode(node *stringNode[V], prefix string, depth int) bool {
+	if depth == len(prefix)-1 {
+		if node.children == nil {
+			return false
+		}
+		b := prefix[depth]
+		target, ok := node.children[b]
+		if !ok {
+			return false
+		}
+		removedCount := m.countValues(target)
+		m.size -= removedCount
+		delete(node.children, b)
+		return true
+	}
+	if node.children == nil {
+		return false
+	}
+	b := prefix[depth]
+	next, ok := node.children[b]
+	if !ok {
+		return false
+	}
+	removed := m.removePrefixNode(next, prefix, depth+1)
+	if removed {
+		if !next.hasValue && len(next.children) == 0 {
+			delete(node.children, b)
+		}
+	}
+	return removed
+}
+
+func (m *stringMap[V]) LongestPrefixOf(query string) (string, V, bool) {
+	node := m.root
+	var longestKey string
+	var longestVal V
+	var found bool
+
+	if node.hasValue {
+		longestKey = ""
+		longestVal = node.value
+		found = true
+	}
+
+	for i := 0; i < len(query); i++ {
+		if node.children == nil {
+			break
+		}
+		next, ok := node.children[query[i]]
+		if !ok {
+			break
+		}
+		node = next
+		if node.hasValue {
+			longestKey = query[:i+1]
+			longestVal = node.value
+			found = true
+		}
+	}
+	return longestKey, longestVal, found
+}
+
+func (m *stringMap[V]) ShortestPrefixOf(query string) (string, V, bool) {
+	node := m.root
+	if node.hasValue {
+		return "", node.value, true
+	}
+	for i := 0; i < len(query); i++ {
+		if node.children == nil {
+			break
+		}
+		next, ok := node.children[query[i]]
+		if !ok {
+			break
+		}
+		node = next
+		if node.hasValue {
+			return query[:i+1], node.value, true
+		}
+	}
+	var zero V
+	return "", zero, false
+}
+
+func (m *stringMap[V]) PrefixesOf(query string) iter.Seq2[string, V] {
+	return func(yield func(string, V) bool) {
+		node := m.root
+		if node.hasValue {
+			if !yield("", node.value) {
+				return
+			}
+		}
+		for i := 0; i < len(query); i++ {
+			if node.children == nil {
+				break
+			}
+			next, ok := node.children[query[i]]
+			if !ok {
+				break
+			}
+			node = next
+			if node.hasValue {
+				if !yield(query[:i+1], node.value) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// StringSet Implementation
+// -----------------------------------------------------------------------------
+
+var _ Set[string] = (*stringSet)(nil)
+
+type stringSet struct {
+	m *stringMap[struct{}]
+}
+
+func newStringSet() *stringSet {
+	return &stringSet{m: newStringMap[struct{}]()}
+}
+
+func (s *stringSet) Size() int {
+	return s.m.Size()
+}
+
+func (s *stringSet) Empty() bool {
+	return s.m.Empty()
+}
+
+func (s *stringSet) Clear() {
+	s.m.Clear()
+}
+
+func (s *stringSet) All() iter.Seq[string] {
+	return s.m.Keys()
+}
+
+func (s *stringSet) Add(item string) {
+	s.m.Put(item, struct{}{})
+}
+
+func (s *stringSet) Remove() string {
+	for k := range s.m.Keys() {
+		s.m.Remove(k)
+		return k
+	}
+	panic("cannot remove from an empty set")
+}
+
+func (s *stringSet) AddAll(sequence iter.Seq[string]) {
+	for t := range sequence {
+		s.Add(t)
+	}
+}
+
+func (s *stringSet) RemoveElement(item string) {
+	s.m.Remove(item)
+}
+
+func (s *stringSet) RemoveAll(other collections.Collection[string]) {
+	for t := range other.All() {
+		s.RemoveElement(t)
+	}
+}
+
+func (s *stringSet) RetainAll(other collections.Collection[string]) {
+	newMap := newStringMap[struct{}]()
+	for t := range other.All() {
+		if s.Contains(t) {
+			newMap.Put(t, struct{}{})
+		}
+	}
+	s.m = newMap
+}
+
+func (s *stringSet) Contains(item string) bool {
+	return s.m.ContainsKey(item)
+}
+
+func (s *stringSet) ContainsAll(other collections.Collection[string]) bool {
+	for item := range other.All() {
+		if !s.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *stringSet) HasPrefix(prefix string) bool {
+	return s.m.HasPrefix(prefix)
+}
+
+func (s *stringSet) ElementsWithPrefix(prefix string) iter.Seq[string] {
+	return s.m.KeysWithPrefix(prefix)
+}
+
+func (s *stringSet) RemovePrefix(prefix string) {
+	s.m.RemovePrefix(prefix)
+}
+
+func (s *stringSet) LongestPrefixOf(query string) (string, bool) {
+	k, _, ok := s.m.LongestPrefixOf(query)
+	return k, ok
+}
+
+func (s *stringSet) ShortestPrefixOf(query string) (string, bool) {
+	k, _, ok := s.m.ShortestPrefixOf(query)
+	return k, ok
+}
+
+func (s *stringSet) PrefixesOf(query string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for k := range s.m.PrefixesOf(query) {
+			if !yield(k) {
+				return
+			}
+		}
+	}
+}
+
+func (s *stringSet) String() string {
+	vals := make([]string, 0, s.Size())
+	for item := range s.All() {
+		vals = append(vals, fmt.Sprintf("%+v", item))
+	}
+	return "[" + strings.Join(vals, ", ") + "]"
+}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -1,0 +1,80 @@
+// Package trie provides Trie backed map and set implementations.
+package trie
+
+import (
+	"iter"
+
+	"github.com/lock14/collections"
+)
+
+// Map is a Trie that implements collections.MutableMap and provides prefix operations.
+type Map[K any, V any] interface {
+	collections.MutableMap[K, V]
+
+	// HasPrefix returns true if there is at least one key in the map starting with the given prefix.
+	HasPrefix(prefix K) bool
+
+	// KeysWithPrefix returns an iterator over all keys that start with the given prefix.
+	KeysWithPrefix(prefix K) iter.Seq[K]
+
+	// ValuesWithPrefix returns an iterator over all values whose keys start with the given prefix.
+	ValuesWithPrefix(prefix K) iter.Seq[V]
+
+	// EntriesWithPrefix returns an iterator over all key-value pairs where the key starts with the given prefix.
+	EntriesWithPrefix(prefix K) iter.Seq2[K, V]
+
+	// RemovePrefix removes all key-value pairs whose keys start with the given prefix.
+	RemovePrefix(prefix K)
+
+	// LongestPrefixOf returns the longest key in the map that is a prefix of the given query.
+	LongestPrefixOf(query K) (K, V, bool)
+
+	// ShortestPrefixOf returns the shortest key in the map that is a prefix of the given query.
+	ShortestPrefixOf(query K) (K, V, bool)
+
+	// PrefixesOf returns an iterator over all keys in the map that are a prefix of the given query.
+	PrefixesOf(query K) iter.Seq2[K, V]
+}
+
+// Set is a Trie that implements collections.MutableSet and provides prefix operations.
+type Set[K any] interface {
+	collections.MutableSet[K]
+
+	// HasPrefix returns true if there is at least one element in the set starting with the given prefix.
+	HasPrefix(prefix K) bool
+
+	// ElementsWithPrefix returns an iterator over all elements that start with the given prefix.
+	ElementsWithPrefix(prefix K) iter.Seq[K]
+
+	// RemovePrefix removes all elements that start with the given prefix.
+	RemovePrefix(prefix K)
+
+	// LongestPrefixOf returns the longest element in the set that is a prefix of the given query.
+	LongestPrefixOf(query K) (K, bool)
+
+	// ShortestPrefixOf returns the shortest element in the set that is a prefix of the given query.
+	ShortestPrefixOf(query K) (K, bool)
+
+	// PrefixesOf returns an iterator over all elements in the set that are a prefix of the given query.
+	PrefixesOf(query K) iter.Seq[K]
+}
+
+// NewMap creates an empty Trie map for string keys.
+func NewMap[V any]() Map[string, V] {
+	return newStringMap[V]()
+}
+
+// NewSet creates an empty Trie set for string elements.
+func NewSet() Set[string] {
+	return newStringSet()
+}
+
+// NewSliceMap creates an empty Trie map for slice keys of any comparable element type.
+func NewSliceMap[E comparable, V any]() Map[[]E, V] {
+	return newSliceMap[E, V]()
+}
+
+// NewSliceSet creates an empty Trie set for slice elements of any comparable element type.
+func NewSliceSet[E comparable]() Set[[]E] {
+	return newSliceSet[E]()
+}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -603,6 +603,52 @@ func TestMoreCoverage(t *testing.T) {
 	if count != 0 {
 		t.Errorf("expected 0")
 	}
+
+	// SliceMap missing key Get
+	if _, ok := sm.Get([]byte("missing")); ok {
+		t.Errorf("expected false")
+	}
+
+	// Root values
+	m.Put("", 999)
+	if m.Size() != 2 {
+		t.Errorf("size should be 2")
+	}
+	if v, ok := m.Get(""); !ok || v != 999 {
+		t.Errorf("Get empty string failed")
+	}
+	if !m.HasPrefix("") {
+		t.Errorf("HasPrefix empty string failed")
+	}
+	lk, lv, lok := m.LongestPrefixOf("xyz")
+	if !lok || lk != "" || lv != 999 {
+		t.Errorf("LongestPrefixOf empty failed")
+	}
+
+	sm.Put([]byte{}, 999)
+	if sm.Size() != 2 {
+		t.Errorf("size should be 2")
+	}
+	if v, ok := sm.Get([]byte{}); !ok || v != 999 {
+		t.Errorf("Get empty slice failed")
+	}
+	if !sm.HasPrefix([]byte{}) {
+		t.Errorf("HasPrefix empty slice failed")
+	}
+	slk, slv, slok := sm.LongestPrefixOf([]byte("xyz"))
+	if !slok || len(slk) != 0 || slv != 999 {
+		t.Errorf("LongestPrefixOf empty slice failed")
+	}
+
+	// Remove root values
+	m.Remove("")
+	if m.Size() != 1 {
+		t.Errorf("Remove empty string failed")
+	}
+	sm.Remove([]byte{})
+	if sm.Size() != 1 {
+		t.Errorf("Remove empty slice failed")
+	}
 }
 
 func BenchmarkStringMap_Put(b *testing.B) {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -262,14 +262,14 @@ func TestStringSet_Basic(t *testing.T) {
 	s := NewSet()
 	s.Add("hello")
 	s.Add("world")
-	
+
 	if s.Size() != 2 {
 		t.Errorf("size = %d", s.Size())
 	}
 	if !s.Contains("hello") {
 		t.Errorf("Contains(hello) = false")
 	}
-	
+
 	lk, lok := s.LongestPrefixOf("hello world")
 	if !lok || lk != "hello" {
 		t.Errorf("LongestPrefixOf = %v, %v", lk, lok)
@@ -280,12 +280,12 @@ func TestStringMap_Values(t *testing.T) {
 	m := NewMap[int]()
 	m.Put("a", 1)
 	m.Put("b", 2)
-	
+
 	vals := slices.Collect(m.Values())
 	if !slices.Contains(vals, 1) || !slices.Contains(vals, 2) {
 		t.Errorf("Values failed")
 	}
-	
+
 	vp := slices.Collect(m.ValuesWithPrefix("a"))
 	if len(vp) != 1 || vp[0] != 1 {
 		t.Errorf("ValuesWithPrefix failed")
@@ -295,30 +295,30 @@ func TestStringMap_Values(t *testing.T) {
 func TestStringSet_Remaining(t *testing.T) {
 	s := NewSet()
 	s.Add("x")
-	
+
 	s2 := NewSet()
 	s2.AddAll(s.All())
 	if !s2.ContainsAll(s) {
 		t.Errorf("ContainsAll failed")
 	}
-	
+
 	s2.RemoveAll(s)
 	if !s2.Empty() {
 		t.Errorf("RemoveAll failed")
 	}
-	
+
 	s2.Add("x")
 	s2.Add("y")
 	s2.RetainAll(s)
 	if s2.Size() != 1 {
 		t.Errorf("RetainAll failed")
 	}
-	
+
 	v := s2.Remove()
 	if v != "x" {
 		t.Errorf("Remove failed")
 	}
-	
+
 	func() {
 		defer func() {
 			if r := recover(); r == nil {
@@ -334,18 +334,18 @@ func TestStringMap_EarlyExit(t *testing.T) {
 	m.Put("a", 1)
 	m.Put("ab", 2)
 	m.Put("b", 3)
-	
+
 	count := 0
-	for _, _ = range m.All() {
+	for range m.All() {
 		count++
 		break
 	}
 	if count != 1 {
 		t.Errorf("All() early exit failed")
 	}
-	
+
 	count = 0
-	for _ = range m.KeysWithPrefix("a") {
+	for range m.KeysWithPrefix("a") {
 		count++
 		break
 	}
@@ -354,7 +354,7 @@ func TestStringMap_EarlyExit(t *testing.T) {
 	}
 
 	count = 0
-	for _, _ = range m.PrefixesOf("abc") {
+	for range m.PrefixesOf("abc") {
 		count++
 		break
 	}
@@ -368,18 +368,18 @@ func TestSliceMap_EarlyExit(t *testing.T) {
 	m.Put([]byte("a"), 1)
 	m.Put([]byte("ab"), 2)
 	m.Put([]byte("b"), 3)
-	
+
 	count := 0
-	for _, _ = range m.All() {
+	for range m.All() {
 		count++
 		break
 	}
 	if count != 1 {
 		t.Errorf("All() early exit failed")
 	}
-	
+
 	count = 0
-	for _ = range m.KeysWithPrefix([]byte("a")) {
+	for range m.KeysWithPrefix([]byte("a")) {
 		count++
 		break
 	}
@@ -388,7 +388,7 @@ func TestSliceMap_EarlyExit(t *testing.T) {
 	}
 
 	count = 0
-	for _, _ = range m.PrefixesOf([]byte("abc")) {
+	for range m.PrefixesOf([]byte("abc")) {
 		count++
 		break
 	}
@@ -402,7 +402,7 @@ func TestStringSet_EarlyExit(t *testing.T) {
 	s.Add("a")
 	s.Add("b")
 	count := 0
-	for _ = range s.All() {
+	for range s.All() {
 		count++
 		break
 	}
@@ -410,7 +410,7 @@ func TestStringSet_EarlyExit(t *testing.T) {
 		t.Errorf("All early exit failed")
 	}
 	count = 0
-	for _ = range s.PrefixesOf("abc") {
+	for range s.PrefixesOf("abc") {
 		count++
 		break
 	}
@@ -424,7 +424,7 @@ func TestSliceSet_EarlyExit(t *testing.T) {
 	s.Add([]byte("a"))
 	s.Add([]byte("b"))
 	count := 0
-	for _ = range s.All() {
+	for range s.All() {
 		count++
 		break
 	}
@@ -432,7 +432,7 @@ func TestSliceSet_EarlyExit(t *testing.T) {
 		t.Errorf("All early exit failed")
 	}
 	count = 0
-	for _ = range s.PrefixesOf([]byte("abc")) {
+	for range s.PrefixesOf([]byte("abc")) {
 		count++
 		break
 	}
@@ -453,13 +453,13 @@ func TestStringMap_EdgeCases(t *testing.T) {
 	if ok {
 		t.Errorf("expected false")
 	}
-	
+
 	// RemovePrefix empty string clears map
 	m.RemovePrefix("")
 	if !m.Empty() {
 		t.Errorf("expected empty map")
 	}
-	
+
 	// RemovePrefix where prefix doesn't exist
 	m.Put("a", 1)
 	m.RemovePrefix("ab")
@@ -483,7 +483,7 @@ func TestSliceMap_EdgeCases(t *testing.T) {
 	if ok {
 		t.Errorf("expected false")
 	}
-	
+
 	m.RemovePrefix(nil) // should clear map
 	if !m.Empty() {
 		t.Errorf("expected empty map")
@@ -493,7 +493,7 @@ func TestSliceMap_EdgeCases(t *testing.T) {
 	if !m.Empty() {
 		t.Errorf("expected empty map")
 	}
-	
+
 	m.Put([]byte("a"), 1)
 	m.RemovePrefix([]byte("ab"))
 	if m.Size() != 1 {
@@ -510,19 +510,19 @@ func TestStringMap_MoreEdgeCases(t *testing.T) {
 	m.Put("a", 1)
 	// Try to remove "ab", depth reaches 'a', but 'b' is not in 'a's children
 	m.RemovePrefix("ab")
-	
+
 	// Values tests with early exit
 	count := 0
-	for _ = range m.Values() {
+	for range m.Values() {
 		count++
 		break
 	}
 	if count != 1 {
 		t.Errorf("Values early exit failed")
 	}
-	
+
 	count = 0
-	for _ = range m.ValuesWithPrefix("a") {
+	for range m.ValuesWithPrefix("a") {
 		count++
 		break
 	}
@@ -535,18 +535,18 @@ func TestSliceMap_MoreEdgeCases(t *testing.T) {
 	m := NewSliceMap[byte, int]()
 	m.Put([]byte("a"), 1)
 	m.RemovePrefix([]byte("ab"))
-	
+
 	count := 0
-	for _ = range m.Values() {
+	for range m.Values() {
 		count++
 		break
 	}
 	if count != 1 {
 		t.Errorf("Values early exit failed")
 	}
-	
+
 	count = 0
-	for _ = range m.ValuesWithPrefix([]byte("a")) {
+	for range m.ValuesWithPrefix([]byte("a")) {
 		count++
 		break
 	}
@@ -566,22 +566,22 @@ func TestMoreCoverage(t *testing.T) {
 	if m.HasPrefix("ab") {
 		t.Errorf("expected false")
 	}
-	
+
 	// EntriesWithPrefix on missing
 	count := 0
-	for _ = range m.EntriesWithPrefix("ab") {
+	for range m.EntriesWithPrefix("ab") {
 		count++
 	}
 	if count != 0 {
 		t.Errorf("expected 0")
 	}
-	for _ = range m.KeysWithPrefix("ab") {
+	for range m.KeysWithPrefix("ab") {
 		count++
 	}
 	if count != 0 {
 		t.Errorf("expected 0")
 	}
-	
+
 	// SliceMap edge cases
 	sm := NewSliceMap[byte, int]()
 	if sm.HasPrefix([]byte("a")) {
@@ -591,13 +591,13 @@ func TestMoreCoverage(t *testing.T) {
 	if sm.HasPrefix([]byte("ab")) {
 		t.Errorf("expected false")
 	}
-	for _ = range sm.EntriesWithPrefix([]byte("ab")) {
+	for range sm.EntriesWithPrefix([]byte("ab")) {
 		count++
 	}
 	if count != 0 {
 		t.Errorf("expected 0")
 	}
-	for _ = range sm.KeysWithPrefix([]byte("ab")) {
+	for range sm.KeysWithPrefix([]byte("ab")) {
 		count++
 	}
 	if count != 0 {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -1,0 +1,654 @@
+package trie
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+)
+
+type kv struct {
+	k string
+	v int
+}
+
+func TestStringMap_BasicOperations(t *testing.T) {
+	cases := []struct {
+		name      string
+		puts      []kv
+		removes   []string
+		gets      []string
+		wantVals  []int
+		wantFound []bool
+		wantSize  int
+		wantEmpty bool
+	}{
+		{
+			name:      "empty",
+			gets:      []string{"a"},
+			wantVals:  []int{0},
+			wantFound: []bool{false},
+			wantSize:  0,
+			wantEmpty: true,
+		},
+		{
+			name:      "single_element",
+			puts:      []kv{{"hello", 1}},
+			gets:      []string{"hello", "hell", "helloo"},
+			wantVals:  []int{1, 0, 0},
+			wantFound: []bool{true, false, false},
+			wantSize:  1,
+			wantEmpty: false,
+		},
+		{
+			name:      "overwrite",
+			puts:      []kv{{"hello", 1}, {"hello", 2}},
+			gets:      []string{"hello"},
+			wantVals:  []int{2},
+			wantFound: []bool{true},
+			wantSize:  1,
+		},
+		{
+			name:      "remove",
+			puts:      []kv{{"a", 1}, {"ab", 2}, {"abc", 3}},
+			removes:   []string{"ab", "x"},
+			gets:      []string{"a", "ab", "abc"},
+			wantVals:  []int{1, 0, 3},
+			wantFound: []bool{true, false, true},
+			wantSize:  2,
+		},
+		{
+			name:      "clear",
+			puts:      []kv{{"a", 1}, {"b", 2}},
+			removes:   []string{"_clear"},
+			gets:      []string{"a", "b"},
+			wantVals:  []int{0, 0},
+			wantFound: []bool{false, false},
+			wantSize:  0,
+			wantEmpty: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewMap[int]()
+			for _, p := range tc.puts {
+				m.Put(p.k, p.v)
+			}
+			for _, r := range tc.removes {
+				if r == "_clear" {
+					m.Clear()
+				} else {
+					m.Remove(r)
+				}
+			}
+
+			if m.Size() != tc.wantSize {
+				t.Errorf("got size %d, want %d", m.Size(), tc.wantSize)
+			}
+			if m.Empty() != tc.wantEmpty {
+				t.Errorf("got empty %v, want %v", m.Empty(), tc.wantEmpty)
+			}
+
+			for i, g := range tc.gets {
+				v, ok := m.Get(g)
+				if v != tc.wantVals[i] {
+					t.Errorf("Get(%q) val = %d, want %d", g, v, tc.wantVals[i])
+				}
+				if ok != tc.wantFound[i] {
+					t.Errorf("Get(%q) ok = %v, want %v", g, ok, tc.wantFound[i])
+				}
+				if m.ContainsKey(g) != tc.wantFound[i] {
+					t.Errorf("ContainsKey(%q) = %v, want %v", g, m.ContainsKey(g), tc.wantFound[i])
+				}
+			}
+		})
+	}
+}
+
+func TestStringMap_PrefixOperations(t *testing.T) {
+	cases := []struct {
+		name               string
+		puts               []kv
+		hasPrefix          string
+		wantHasPrefix      bool
+		prefixQuery        string
+		wantKeysWithPrefix []string
+		longestQuery       string
+		wantLongestKey     string
+		wantLongestFound   bool
+		shortestQuery      string
+		wantShortestKey    string
+		wantShortestFound  bool
+		prefixesOfQuery    string
+		wantPrefixesOf     []string
+	}{
+		{
+			name:               "empty_trie",
+			hasPrefix:          "a",
+			wantHasPrefix:      false,
+			prefixQuery:        "a",
+			wantKeysWithPrefix: []string{},
+			longestQuery:       "a",
+			shortestQuery:      "a",
+			prefixesOfQuery:    "a",
+			wantPrefixesOf:     []string{},
+		},
+		{
+			name:               "prefix_matches",
+			puts:               []kv{{"app", 1}, {"apple", 2}, {"ape", 3}, {"bat", 4}},
+			hasPrefix:          "ap",
+			wantHasPrefix:      true,
+			prefixQuery:        "ap",
+			wantKeysWithPrefix: []string{"ape", "app", "apple"},
+			longestQuery:       "apple pie",
+			wantLongestKey:     "apple",
+			wantLongestFound:   true,
+			shortestQuery:      "apple pie",
+			wantShortestKey:    "app",
+			wantShortestFound:  true,
+			prefixesOfQuery:    "apple pie",
+			wantPrefixesOf:     []string{"app", "apple"},
+		},
+		{
+			name:               "exact_match_as_prefix",
+			puts:               []kv{{"cat", 1}},
+			hasPrefix:          "cat",
+			wantHasPrefix:      true,
+			prefixQuery:        "cat",
+			wantKeysWithPrefix: []string{"cat"},
+			longestQuery:       "cat",
+			wantLongestKey:     "cat",
+			wantLongestFound:   true,
+		},
+		{
+			name:               "no_prefix_match",
+			puts:               []kv{{"dog", 1}},
+			hasPrefix:          "cat",
+			wantHasPrefix:      false,
+			prefixQuery:        "cat",
+			wantKeysWithPrefix: []string{},
+			longestQuery:       "cat",
+			wantLongestFound:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewMap[int]()
+			for _, p := range tc.puts {
+				m.Put(p.k, p.v)
+			}
+
+			if m.HasPrefix(tc.hasPrefix) != tc.wantHasPrefix {
+				t.Errorf("HasPrefix(%q) = %v, want %v", tc.hasPrefix, m.HasPrefix(tc.hasPrefix), tc.wantHasPrefix)
+			}
+
+			gotKeys := slices.Collect(m.KeysWithPrefix(tc.prefixQuery))
+			if !reflect.DeepEqual(gotKeys, tc.wantKeysWithPrefix) {
+				// if both are empty slices, DeepEqual might fail if one is nil and one is empty, so handle that
+				if len(gotKeys) != 0 || len(tc.wantKeysWithPrefix) != 0 {
+					t.Errorf("KeysWithPrefix(%q) = %v, want %v", tc.prefixQuery, gotKeys, tc.wantKeysWithPrefix)
+				}
+			}
+
+			lk, _, lok := m.LongestPrefixOf(tc.longestQuery)
+			if lok != tc.wantLongestFound || (lok && lk != tc.wantLongestKey) {
+				t.Errorf("LongestPrefixOf(%q) = (%q, %v), want (%q, %v)", tc.longestQuery, lk, lok, tc.wantLongestKey, tc.wantLongestFound)
+			}
+
+			sk, _, sok := m.ShortestPrefixOf(tc.shortestQuery)
+			if sok != tc.wantShortestFound || (sok && sk != tc.wantShortestKey) {
+				t.Errorf("ShortestPrefixOf(%q) = (%q, %v), want (%q, %v)", tc.shortestQuery, sk, sok, tc.wantShortestKey, tc.wantShortestFound)
+			}
+
+			var gotPrefixes []string
+			for k := range m.PrefixesOf(tc.prefixesOfQuery) {
+				gotPrefixes = append(gotPrefixes, k)
+			}
+			if !reflect.DeepEqual(gotPrefixes, tc.wantPrefixesOf) {
+				if len(gotPrefixes) != 0 || len(tc.wantPrefixesOf) != 0 {
+					t.Errorf("PrefixesOf(%q) = %v, want %v", tc.prefixesOfQuery, gotPrefixes, tc.wantPrefixesOf)
+				}
+			}
+		})
+	}
+}
+
+func TestStringMap_RemovePrefix(t *testing.T) {
+	m := NewMap[int]()
+	m.Put("app", 1)
+	m.Put("apple", 2)
+	m.Put("ape", 3)
+	m.Put("bat", 4)
+
+	m.RemovePrefix("ap")
+
+	if m.Size() != 1 {
+		t.Errorf("got size %d, want 1", m.Size())
+	}
+	if !m.ContainsKey("bat") {
+		t.Errorf("expected bat to remain")
+	}
+	if m.ContainsKey("app") || m.ContainsKey("ape") {
+		t.Errorf("expected ap* keys to be removed")
+	}
+}
+
+func TestSliceMap_Basic(t *testing.T) {
+	m := NewSliceMap[int, string]()
+	m.Put([]int{1, 2, 3}, "a")
+	m.Put([]int{1, 2}, "b")
+
+	if m.Size() != 2 {
+		t.Errorf("got size %d, want 2", m.Size())
+	}
+
+	v, ok := m.Get([]int{1, 2})
+	if !ok || v != "b" {
+		t.Errorf("Get([1,2]) = %v, %v, want b, true", v, ok)
+	}
+
+	lk, lv, lok := m.LongestPrefixOf([]int{1, 2, 3, 4})
+	if !lok || lv != "a" || !reflect.DeepEqual(lk, []int{1, 2, 3}) {
+		t.Errorf("LongestPrefixOf = %v, %v, %v", lk, lv, lok)
+	}
+}
+
+func TestStringSet_Basic(t *testing.T) {
+	s := NewSet()
+	s.Add("hello")
+	s.Add("world")
+	
+	if s.Size() != 2 {
+		t.Errorf("size = %d", s.Size())
+	}
+	if !s.Contains("hello") {
+		t.Errorf("Contains(hello) = false")
+	}
+	
+	lk, lok := s.LongestPrefixOf("hello world")
+	if !lok || lk != "hello" {
+		t.Errorf("LongestPrefixOf = %v, %v", lk, lok)
+	}
+}
+
+func TestStringMap_Values(t *testing.T) {
+	m := NewMap[int]()
+	m.Put("a", 1)
+	m.Put("b", 2)
+	
+	vals := slices.Collect(m.Values())
+	if !slices.Contains(vals, 1) || !slices.Contains(vals, 2) {
+		t.Errorf("Values failed")
+	}
+	
+	vp := slices.Collect(m.ValuesWithPrefix("a"))
+	if len(vp) != 1 || vp[0] != 1 {
+		t.Errorf("ValuesWithPrefix failed")
+	}
+}
+
+func TestStringSet_Remaining(t *testing.T) {
+	s := NewSet()
+	s.Add("x")
+	
+	s2 := NewSet()
+	s2.AddAll(s.All())
+	if !s2.ContainsAll(s) {
+		t.Errorf("ContainsAll failed")
+	}
+	
+	s2.RemoveAll(s)
+	if !s2.Empty() {
+		t.Errorf("RemoveAll failed")
+	}
+	
+	s2.Add("x")
+	s2.Add("y")
+	s2.RetainAll(s)
+	if s2.Size() != 1 {
+		t.Errorf("RetainAll failed")
+	}
+	
+	v := s2.Remove()
+	if v != "x" {
+		t.Errorf("Remove failed")
+	}
+	
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("expected panic")
+			}
+		}()
+		s2.Remove()
+	}()
+}
+
+func TestStringMap_EarlyExit(t *testing.T) {
+	m := NewMap[int]()
+	m.Put("a", 1)
+	m.Put("ab", 2)
+	m.Put("b", 3)
+	
+	count := 0
+	for _, _ = range m.All() {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("All() early exit failed")
+	}
+	
+	count = 0
+	for _ = range m.KeysWithPrefix("a") {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("KeysWithPrefix early exit failed")
+	}
+
+	count = 0
+	for _, _ = range m.PrefixesOf("abc") {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("PrefixesOf early exit failed")
+	}
+}
+
+func TestSliceMap_EarlyExit(t *testing.T) {
+	m := NewSliceMap[byte, int]()
+	m.Put([]byte("a"), 1)
+	m.Put([]byte("ab"), 2)
+	m.Put([]byte("b"), 3)
+	
+	count := 0
+	for _, _ = range m.All() {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("All() early exit failed")
+	}
+	
+	count = 0
+	for _ = range m.KeysWithPrefix([]byte("a")) {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("KeysWithPrefix early exit failed")
+	}
+
+	count = 0
+	for _, _ = range m.PrefixesOf([]byte("abc")) {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("PrefixesOf early exit failed")
+	}
+}
+
+func TestStringSet_EarlyExit(t *testing.T) {
+	s := NewSet()
+	s.Add("a")
+	s.Add("b")
+	count := 0
+	for _ = range s.All() {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("All early exit failed")
+	}
+	count = 0
+	for _ = range s.PrefixesOf("abc") {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("PrefixesOf early exit failed")
+	}
+}
+
+func TestSliceSet_EarlyExit(t *testing.T) {
+	s := NewSliceSet[byte]()
+	s.Add([]byte("a"))
+	s.Add([]byte("b"))
+	count := 0
+	for _ = range s.All() {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("All early exit failed")
+	}
+	count = 0
+	for _ = range s.PrefixesOf([]byte("abc")) {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("PrefixesOf early exit failed")
+	}
+}
+
+func TestStringMap_EdgeCases(t *testing.T) {
+	m := NewMap[int]()
+	// ShortestPrefixOf missing characters / nil children
+	_, _, ok := m.ShortestPrefixOf("abc")
+	if ok {
+		t.Errorf("expected false")
+	}
+	m.Put("a", 1)
+	_, _, ok = m.ShortestPrefixOf("xyz")
+	if ok {
+		t.Errorf("expected false")
+	}
+	
+	// RemovePrefix empty string clears map
+	m.RemovePrefix("")
+	if !m.Empty() {
+		t.Errorf("expected empty map")
+	}
+	
+	// RemovePrefix where prefix doesn't exist
+	m.Put("a", 1)
+	m.RemovePrefix("ab")
+	if m.Size() != 1 {
+		t.Errorf("size should be 1")
+	}
+	m.RemovePrefix("x")
+	if m.Size() != 1 {
+		t.Errorf("size should be 1")
+	}
+}
+
+func TestSliceMap_EdgeCases(t *testing.T) {
+	m := NewSliceMap[byte, int]()
+	_, _, ok := m.ShortestPrefixOf([]byte("abc"))
+	if ok {
+		t.Errorf("expected false")
+	}
+	m.Put([]byte("a"), 1)
+	_, _, ok = m.ShortestPrefixOf([]byte("xyz"))
+	if ok {
+		t.Errorf("expected false")
+	}
+	
+	m.RemovePrefix(nil) // should clear map
+	if !m.Empty() {
+		t.Errorf("expected empty map")
+	}
+	m.Put([]byte("a"), 1)
+	m.RemovePrefix([]byte{}) // also clears map
+	if !m.Empty() {
+		t.Errorf("expected empty map")
+	}
+	
+	m.Put([]byte("a"), 1)
+	m.RemovePrefix([]byte("ab"))
+	if m.Size() != 1 {
+		t.Errorf("size should be 1")
+	}
+	m.RemovePrefix([]byte("x"))
+	if m.Size() != 1 {
+		t.Errorf("size should be 1")
+	}
+}
+
+func TestStringMap_MoreEdgeCases(t *testing.T) {
+	m := NewMap[int]()
+	m.Put("a", 1)
+	// Try to remove "ab", depth reaches 'a', but 'b' is not in 'a's children
+	m.RemovePrefix("ab")
+	
+	// Values tests with early exit
+	count := 0
+	for _ = range m.Values() {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("Values early exit failed")
+	}
+	
+	count = 0
+	for _ = range m.ValuesWithPrefix("a") {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("ValuesWithPrefix early exit failed")
+	}
+}
+
+func TestSliceMap_MoreEdgeCases(t *testing.T) {
+	m := NewSliceMap[byte, int]()
+	m.Put([]byte("a"), 1)
+	m.RemovePrefix([]byte("ab"))
+	
+	count := 0
+	for _ = range m.Values() {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("Values early exit failed")
+	}
+	
+	count = 0
+	for _ = range m.ValuesWithPrefix([]byte("a")) {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("ValuesWithPrefix early exit failed")
+	}
+}
+
+func TestMoreCoverage(t *testing.T) {
+	// StringMap edge cases
+	m := NewMap[int]()
+	// HasPrefix on nil children
+	if m.HasPrefix("a") {
+		t.Errorf("expected false")
+	}
+	m.Put("a", 1)
+	if m.HasPrefix("ab") {
+		t.Errorf("expected false")
+	}
+	
+	// EntriesWithPrefix on missing
+	count := 0
+	for _ = range m.EntriesWithPrefix("ab") {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0")
+	}
+	for _ = range m.KeysWithPrefix("ab") {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0")
+	}
+	
+	// SliceMap edge cases
+	sm := NewSliceMap[byte, int]()
+	if sm.HasPrefix([]byte("a")) {
+		t.Errorf("expected false")
+	}
+	sm.Put([]byte("a"), 1)
+	if sm.HasPrefix([]byte("ab")) {
+		t.Errorf("expected false")
+	}
+	for _ = range sm.EntriesWithPrefix([]byte("ab")) {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0")
+	}
+	for _ = range sm.KeysWithPrefix([]byte("ab")) {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0")
+	}
+}
+
+func BenchmarkStringMap_Put(b *testing.B) {
+	m := NewMap[int]()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Put("some_fairly_long_string_prefix", i)
+	}
+}
+
+func BenchmarkSliceMap_Put(b *testing.B) {
+	m := NewSliceMap[byte, int]()
+	key := []byte("some_fairly_long_string_prefix")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Put(key, i)
+	}
+}
+
+func BenchmarkStringMap_Get(b *testing.B) {
+	m := NewMap[int]()
+	m.Put("some_fairly_long_string_prefix", 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Get("some_fairly_long_string_prefix")
+	}
+}
+
+func BenchmarkSliceMap_Get(b *testing.B) {
+	m := NewSliceMap[byte, int]()
+	key := []byte("some_fairly_long_string_prefix")
+	m.Put(key, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Get(key)
+	}
+}
+
+func BenchmarkStringMap_KeysWithPrefix(b *testing.B) {
+	m := NewMap[int]()
+	m.Put("api/v1/users/1", 1)
+	m.Put("api/v1/users/2", 2)
+	m.Put("api/v1/posts/1", 3)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for range m.KeysWithPrefix("api/v1/users") {
+		}
+	}
+}


### PR DESCRIPTION
# PR Description: `feat(trie): Add generic Trie package with Map and Set interfaces`

## Description

This PR introduces a highly optimized `trie` (prefix tree) package to `lock14/collections`, providing `Map` and `Set` implementations specifically tailored for efficient string and slice prefix matching. 

These implementations are ideal for use-cases requiring fast auto-completion, IP/subnet routing, URL path matching, and hierarchical data queries.

### Key Features
- **Map & Set Interfaces**: Exposes simple `Map[K, V]` and `Set[K]` interfaces with both standard collection methods and prefix-specific routing operations:
  - `HasPrefix(K)`
  - `KeysWithPrefix(K)` / `ValuesWithPrefix(K)` / `EntriesWithPrefix(K)` (returning standard `iter.Seq`)
  - `LongestPrefixOf(K)` / `ShortestPrefixOf(K)`
  - `PrefixesOf(K)`
  - `RemovePrefix(K)`
- **`StringMap` & `StringSet`**: Zero-allocation hot paths for string keys. Under the hood, these avoid allocation overhead by iterating directly over the underlying byte representation of Go strings without making copies.
- **`SliceMap` & `SliceSet`**: Fully generic implementations for `[]E` where `E` is any `comparable` type (e.g. `[]byte`, `[]int`, etc).

## Implementation Details
- The underlying structure uses maps for child nodes (`map[byte]*stringNode` and `map[E]*sliceNode`), ensuring $O(1)$ child lookups at each depth of the trie.
- Comprehensive table-driven tests have been included, spanning both basic operations and prefix operations.
- Iterator-based accessors use `iter.Seq` (Go 1.23+ conventions) and natively support early-exits.

## Performance
Benchmarks demonstrate that the hot-path read operations are zero-allocation:
```text
BenchmarkStringMap_Get-16               2651206               446.6 ns/op             0 B/op          0 allocs/op
BenchmarkSliceMap_Get-16                2854777               421.6 ns/op             0 B/op          0 allocs/op
BenchmarkStringMap_Put-16               2592894               472.5 ns/op             0 B/op          0 allocs/op
```
*Note: `Put` benchmark results denote rewriting existing keys, which appropriately skips node allocation.*

## Testing
- [x] Basic Map and Set CRUD operations.
- [x] Prefix queries (Longest, Shortest, KeysWithPrefix, RemovePrefix).
- [x] Edge-cases (Empty tries, missing keys, nil children branching, etc).
- [x] Early-exit (`break`) iterator logic handling.
- **Overall Code Coverage**: `~89.1%` statements.

## Related Issues
*(Link any related issues here if applicable)*
